### PR TITLE
Module packaging (fixes #3)

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,15 @@
+var glob = require('glob')
+var path = require('path')
+var basePath = './build/contracts'
+
+module.exports = glob.sync(
+  path.resolve(__dirname, basePath, '*.json')
+).reduce(function (contracts, file) {
+  var contract = require(file)
+
+  if (contract.contract_name) {
+    contracts[contract.contract_name] = contract
+  }
+
+  return contracts
+}, {})

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "prepublish": "truffle compile",
     "test": "truffle test"
   },
+  "files": [
+    "index.js",
+    "build/"
+  ],
   "author": "Jorge Izquierdo (Aragon)",
   "license": "ISxC",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,10 @@
 {
   "name": "aragon-core",
   "version": "1.0.0",
-  "description": "",
-  "main": "truffle.js",
+  "description": "Core contracts for Aragon",
+  "main": "index.js",
   "scripts": {
+    "prepublish": "truffle compile",
     "test": "truffle test"
   },
   "author": "Jorge Izquierdo (Aragon)",


### PR DESCRIPTION
This PR implements my proposed fixes in #3.

The package is now publishable to npm. Before publishing, npm will build all of the contracts using truffle.

A package entrypoint is provided that loops over all contracts in the build directory and exposes them as a plain object.

Including the example file from the proposal I wrote:

```js
// This is an example of how you could use the package
const contracts = require('aragon-core')

// All of the contracts are exposed in the package as you would expect,
// so a contract named e.g. ``KeybaseRegistry`` would be accessible in
// ``contracts.KeybaseRegistry``.

// One could then interact with them through a package like ``truffle-contract``
const provider = new Web3.providers.HttpProvider('http://localhost:8545')
const contract = require('truffle-contract')
 
const KeybaseRegistryContract = contract(contracts.KeybaseRegistry)
KeybaseRegistryContract.setProvider(provider)
```

Only ``index.js`` and the build directory are published to keep the fingerprint small.

I will open a PR for the ÐApp to use this package, once the first version is published 🕺 

@izqui edit to make sure Commiteth regex works :)
Fixes #3 