### PR TITLE
Speed up CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ dist: trusty
 sudo: false
 group: beta
 language: node_js
+cache:
+  directories:
+    - node_modules
 node_js:
   - "6"
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,5 @@ cache:
     - node_modules
 node_js:
   - "6"
-before_install:
-  - npm i
 script:
   - npm t


### PR DESCRIPTION
This should somewhat speed up the builds in the CI.

Changes

- Caches ``node_modules`` for faster installs
- Removes redundant ``npm install`` step (currently run twice: once before ``install`` in Travis and once during ``install`` in Travis