### PR TITLE
Add missing npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "author": "Jorge Izquierdo (Aragon)",
   "license": "ISxC",
   "dependencies": {
+    "babel-polyfill": "^6.23.0",
     "ethereumjs-util": "^5.1.1",
     "keybase-eth": "^0.3.0",
     "truffle-hdwallet-provider": "0.0.3",


### PR DESCRIPTION
When building from scratch, `npm t` fails with a missing babel-polyfill dependency. 
It may be unnoticed on TravisCI because `node_modules` is cached across builds.

```
root@aragon-core:/usr/src/app# npm t
npm info it worked if it ends with ok
npm info using npm@3.10.10
npm info using node@v6.11.0
npm info lifecycle aragon-core@1.0.0~pretest: aragon-core@1.0.0
npm info lifecycle aragon-core@1.0.0~test: aragon-core@1.0.0

> aragon-core@1.0.0 test /usr/src/app
> truffle test

Error: Cannot find module 'babel-polyfill'
    at Function.Module._resolveFilename (module.js:469:15)
    at Function.Module._load (module.js:417:25)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/usr/src/app/truffle.js:2:1)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
npm info lifecycle aragon-core@1.0.0~test: Failed to exec test script
npm ERR! Test failed.  See above for more details.
```