### PR TITLE
Basic migration that deploys a functional DAO

### DIFF
--- a/contracts/kernel/organs/ApplicationOrgan.sol
+++ b/contracts/kernel/organs/ApplicationOrgan.sol
@@ -15,6 +15,7 @@ contract ApplicationOrgan is IOrgan {
   }
 
   function installApp(uint i, address application) {
+    require(i > 0);
     storageSet(getApplicationStorageKey(i), uint256(application));
     InstalledApplication(application);
   }

--- a/migrations/2_deploy_dao.js
+++ b/migrations/2_deploy_dao.js
@@ -7,6 +7,18 @@ var VaultOrgan = artifacts.require('VaultOrgan')
 
 const organs = [VaultOrgan, TokensOrgan, ActionsOrgan, ApplicationOrgan]
 
+const getNonce = () => {
+  return new Promise((resolve, reject) => {
+    web3.eth.getAccounts((err, acc) => {
+      if (err) return reject(err)
+      web3.eth.getTransactionCount(acc[0], (err, n) => {
+        if (err) return reject(err)
+        resolve(n)
+      })
+    })
+  })
+}
+
 module.exports = (deployer) => {
   let dao = {}
 
@@ -15,15 +27,23 @@ module.exports = (deployer) => {
       dao = MetaOrgan.at(DAO.address)
 
       const firstOrgan = 3
+      let currentNonce = 0
 
       const installOrgan = (organ, i) => {
         const n = i + firstOrgan
         console.log('Installing', organ.constructor._json.contract_name, organ.address, 'at slot', n)
-        return dao.installOrgan(organ.address, n)
+        currentNonce += 1
+
+        return dao.installOrgan(organ.address, n, { nonce: currentNonce + i + 1 })
       }
 
-      const installOrgans = Promise.all(organs.map(organ => organ.new()))
-                              .then(x => Promise.all(x.map(installOrgan)))
-      return installOrgans
+      return getNonce().then(x => {
+        const installOrgans = Promise.all(organs.map((organ, i) => {
+          currentNonce = x + i
+          return organ.new({ nonce: currentNonce })
+        }))
+          .then(x => Promise.all(x.map(installOrgan)))
+        return installOrgans
+      })
     })
 }

--- a/migrations/2_deploy_dao.js
+++ b/migrations/2_deploy_dao.js
@@ -1,0 +1,29 @@
+var DAO = artifacts.require('DAO')
+var MetaOrgan = artifacts.require('MetaOrgan')
+var TokensOrgan = artifacts.require('TokensOrgan')
+var ActionsOrgan = artifacts.require('ActionsOrgan')
+var ApplicationOrgan = artifacts.require('ApplicationOrgan')
+var VaultOrgan = artifacts.require('VaultOrgan')
+
+const organs = [VaultOrgan, TokensOrgan, ActionsOrgan, ApplicationOrgan]
+
+module.exports = (deployer) => {
+  let dao = {}
+
+  return deployer.deploy(DAO, { gas: 4e6 })
+    .then(() => {
+      dao = MetaOrgan.at(DAO.address)
+
+      const firstOrgan = 3
+
+      const installOrgan = (organ, i) => {
+        const n = i + firstOrgan
+        console.log('Installing', organ.constructor._json.contract_name, organ.address, 'at slot', n)
+        return dao.installOrgan(organ.address, n)
+      }
+
+      const installOrgans = Promise.all(organs.map(organ => organ.new()))
+                              .then(x => Promise.all(x.map(installOrgan)))
+      return installOrgans
+    })
+}

--- a/migrations/2_deploy_dao.js
+++ b/migrations/2_deploy_dao.js
@@ -7,17 +7,7 @@ var VaultOrgan = artifacts.require('VaultOrgan')
 
 const organs = [VaultOrgan, TokensOrgan, ActionsOrgan, ApplicationOrgan]
 
-const getNonce = () => {
-  return new Promise((resolve, reject) => {
-    web3.eth.getAccounts((err, acc) => {
-      if (err) return reject(err)
-      web3.eth.getTransactionCount(acc[0], (err, n) => {
-        if (err) return reject(err)
-        resolve(n)
-      })
-    })
-  })
-}
+const { getNonce } = require('../test/helpers/web3')
 
 module.exports = (deployer) => {
   let dao = {}
@@ -27,20 +17,21 @@ module.exports = (deployer) => {
       dao = MetaOrgan.at(DAO.address)
 
       const firstOrgan = 3
-      let currentNonce = 0
+      let nonce = 0
 
       const installOrgan = (organ, i) => {
         const n = i + firstOrgan
         console.log('Installing', organ.constructor._json.contract_name, organ.address, 'at slot', n)
-        currentNonce += 1
+        nonce += 1
 
-        return dao.installOrgan(organ.address, n, { nonce: currentNonce + i + 1 })
+        return dao.installOrgan(organ.address, n, { nonce })
       }
 
-      return getNonce().then(x => {
+      return getNonce(web3).then(x => {
+        nonce = x - 1
         const installOrgans = Promise.all(organs.map((organ, i) => {
-          currentNonce = x + i
-          return organ.new({ nonce: currentNonce })
+          nonce += 1
+          return organ.new({ nonce })
         }))
           .then(x => Promise.all(x.map(installOrgan)))
         return installOrgans

--- a/migrations/3_install_apps.js
+++ b/migrations/3_install_apps.js
@@ -1,6 +1,6 @@
 var DAO = artifacts.require('DAO')
 var ApplicationOrgan = artifacts.require('ApplicationOrgan')
-var Application = artifacts.require('Application')
+var MetaOrgan = artifacts.require('MetaOrgan')
 
 const appNames = ['BylawsApp', 'OwnershipApp', 'VotingApp', 'StatusApp']
 
@@ -14,6 +14,7 @@ const deployApps = daoAddress => {
 
 module.exports = (deployer) => {
   let dao, dao_apps = {}
+  let bylawsAddress = ''
 
   const installApp = (app, i) => {
     const n = i + 1
@@ -29,5 +30,12 @@ module.exports = (deployer) => {
 
       return deployApps(dao.address)
     })
-    .then(deployedApps => Promise.all(deployedApps.map(installApp)))
+    .then(deployedApps => {
+      bylawsAddress = deployedApps[0].address
+      return Promise.all(deployedApps.map(installApp))
+    })
+    .then(() => {
+      console.log('Setting BylawsApp as DAO permissions oracle')
+      return MetaOrgan.at(dao.address).setPermissionsOracle(bylawsAddress)
+    })
 }

--- a/migrations/3_install_apps.js
+++ b/migrations/3_install_apps.js
@@ -1,0 +1,33 @@
+var DAO = artifacts.require('DAO')
+var ApplicationOrgan = artifacts.require('ApplicationOrgan')
+var Application = artifacts.require('Application')
+
+const appNames = ['BylawsApp', 'OwnershipApp', 'VotingApp', 'StatusApp']
+
+const deployApps = daoAddress => {
+  const appsDeploy = appNames
+                      .map(n => artifacts.require(n))
+                      .map(appContract => appContract.new(daoAddress))
+
+  return Promise.all(appsDeploy)
+}
+
+module.exports = (deployer) => {
+  let dao, dao_apps = {}
+
+  const installApp = (app, i) => {
+    const n = i + 1
+    console.log('Installing app', app.constructor._json.contract_name, app.address, 'at slot', n)
+    return dao_apps.installApp(n, app.address)
+  }
+
+  return deployer
+    .then(() => DAO.deployed())
+    .then(d => {
+      dao = d
+      dao_apps = ApplicationOrgan.at(dao.address)
+
+      return deployApps(dao.address)
+    })
+    .then(deployedApps => Promise.all(deployedApps.map(installApp)))
+}

--- a/migrations/3_install_apps.js
+++ b/migrations/3_install_apps.js
@@ -4,10 +4,23 @@ var MetaOrgan = artifacts.require('MetaOrgan')
 
 const appNames = ['BylawsApp', 'OwnershipApp', 'VotingApp', 'StatusApp']
 
-const deployApps = daoAddress => {
+let nonce = 0
+const getNonce = () => {
+  return new Promise((resolve, reject) => {
+    web3.eth.getAccounts((err, acc) => {
+      if (err) return reject(err)
+      web3.eth.getTransactionCount(acc[0], (err, n) => {
+        if (err) return reject(err)
+        resolve(n)
+      })
+    })
+  })
+}
+
+const deployApps = (daoAddress, non) => {
   const appsDeploy = appNames
                       .map(n => artifacts.require(n))
-                      .map(appContract => appContract.new(daoAddress))
+                      .map((appContract, i) => appContract.new(daoAddress, { nonce: non + i }))
 
   return Promise.all(appsDeploy)
 }
@@ -16,10 +29,10 @@ module.exports = (deployer) => {
   let dao, dao_apps = {}
   let bylawsAddress = ''
 
-  const installApp = (app, i) => {
+  const installApp = (app, i, non) => {
     const n = i + 1
     console.log('Installing app', app.constructor._json.contract_name, app.address, 'at slot', n)
-    return dao_apps.installApp(n, app.address)
+    return dao_apps.installApp(n, app.address, { nonce: non + i })
   }
 
   return deployer
@@ -27,12 +40,15 @@ module.exports = (deployer) => {
     .then(d => {
       dao = d
       dao_apps = ApplicationOrgan.at(dao.address)
-
-      return deployApps(dao.address)
+      return getNonce()
+    })
+    .then(x => {
+      nonce = x
+      return deployApps(dao.address, x)
     })
     .then(deployedApps => {
       bylawsAddress = deployedApps[0].address
-      return Promise.all(deployedApps.map(installApp))
+      return Promise.all(deployedApps.map((x, i) => installApp(x, i, appNames.length + nonce)))
     })
     .then(() => {
       console.log('Setting BylawsApp as DAO permissions oracle')

--- a/migrations/4_basic_setup.js
+++ b/migrations/4_basic_setup.js
@@ -1,0 +1,24 @@
+var DAO = artifacts.require('DAO')
+var ApplicationOrgan = artifacts.require('ApplicationOrgan')
+var OwnershipApp = artifacts.require('OwnershipApp')
+var BylawsApp = artifacts.require('BylawsApp')
+var MiniMeToken = artifacts.require('MiniMeToken')
+
+module.exports = (deployer) => {
+  let dao, token = {}
+
+  return deployer
+    .then(() => DAO.deployed())
+    .then(d => {
+      dao = d
+      return MiniMeToken.new('0x0', '0x0', 0, 'TT', 18, '', true)
+    })
+    .then(t => {
+      token = t
+      return token.changeController(dao.address)
+    })
+    .then(() => {
+      console.log('Adding DAO gov token', token.address)
+      return OwnershipApp.at(dao.address).addOrgToken(token.address, 0, 1, 1, { gas: 1e6 })
+    })
+}

--- a/migrations/4_basic_setup.js
+++ b/migrations/4_basic_setup.js
@@ -1,5 +1,4 @@
 var DAO = artifacts.require('DAO')
-var ApplicationOrgan = artifacts.require('ApplicationOrgan')
 var OwnershipApp = artifacts.require('OwnershipApp')
 var BylawsApp = artifacts.require('BylawsApp')
 var MiniMeToken = artifacts.require('MiniMeToken')

--- a/test/helpers/web3.js
+++ b/test/helpers/web3.js
@@ -28,6 +28,18 @@ module.exports = {
     })
   },
 
+  getNonce(web3) {
+    return new Promise((resolve, reject) => {
+      web3.eth.getAccounts((err, acc) => {
+        if (err) return reject(err)
+        web3.eth.getTransactionCount(acc[0], (err, n) => {
+          if (err) return reject(err)
+          resolve(n)
+        })
+      })
+    })
+  },
+
   sign(payload, address) {
     return new Promise((resolve, reject) => {
       web3.eth.sign(address, payload, async (err, signedPayload) => {

--- a/truffle.js
+++ b/truffle.js
@@ -12,6 +12,12 @@ module.exports = {
       provider: require('ethereumjs-testrpc').provider({ gasLimit: 1e8 }),
       gas: 9e6,
     },
+    testrpc: {
+      network_id: 15,
+      host: 'localhost',
+      port: 8545,
+      gas: 1e8,
+    },
     ropsten: {
       network_id: 3,
       // provider: new HDWalletProvider(mnemonic, 'https://ropsten.infura.io/'),

--- a/truffle.js
+++ b/truffle.js
@@ -19,7 +19,7 @@ module.exports = {
     },
     kovan: {
       network_id: 42,
-      // provider:  new HDWalletProvider(mnemonic, 'https://kovan.aragon.one'),
+      provider:  new HDWalletProvider(mnemonic, 'https://kovan.aragon.one'),
       gas: 4.6e6,
     },
     /*


### PR DESCRIPTION
Closes #41.

Built on top of #39, given that it is the most advanced version that works. 

Needed to implement manual nonce management to allow parallel organ and application deployment.

I was able to successfully deploy and configure the [first aragon-core DAO in the testnet](https://kovan.etherscan.io/address/0xa4805523e75bc9baa1abad3a71a4016b61957993) 🎉