### PR TITLE
Fix solidity-inspector being a local dependency by publishing it to npm

### DIFF
--- a/contracts/factories/BasicFactory.sol
+++ b/contracts/factories/BasicFactory.sol
@@ -52,15 +52,17 @@ contract BasicFactory {
     }
 
     function installOrgans(MetaOrgan dao) internal {
-        bytes4[] memory metaorganSigs = new bytes4[](8);
+        bytes4[] memory metaorganSigs = new bytes4[](10);
         metaorganSigs[0] = o0_s0; // setPermissionsOracle(address)
         metaorganSigs[1] = o0_s1; // removeOrgan(bytes4[])
         metaorganSigs[2] = o0_s2; // installOrgan(address,bytes4[])
         metaorganSigs[3] = o0_s3; // installApp(address,bytes4[])
         metaorganSigs[4] = o0_s4; // ceaseToExist()
         metaorganSigs[5] = o0_s5; // get(bytes4)
-        metaorganSigs[6] = o0_s6; // removeApp(bytes4[])
-        metaorganSigs[7] = o0_s7; // replaceKernel(address)
+        metaorganSigs[6] = o0_s6; // updateOrgan(address,bytes4[])
+        metaorganSigs[7] = o0_s7; // removeApp(bytes4[])
+        metaorganSigs[8] = o0_s8; // replaceKernel(address)
+        metaorganSigs[9] = o0_s9; // updateApp(address,bytes4[])
         dao.installOrgan(metaorgan, metaorganSigs);
 
         bytes4[] memory vaultorganSigs = new bytes4[](15);
@@ -91,21 +93,20 @@ contract BasicFactory {
         // Proxies are not working on testrpc, that's why for testing no proxy is created
         Application deployedbylawsapp = Application(_testrpc ? bylawsapp : forwarderFactory.createForwarder(bylawsapp));
         deployedbylawsapp.setDAO(address(dao));
-        bytes4[] memory bylawsappSigs = new bytes4[](14);
+        bytes4[] memory bylawsappSigs = new bytes4[](13);
         bylawsappSigs[0] = a0_s0; // getStatusBylaw(uint256)
         bylawsappSigs[1] = a0_s1; // setCombinatorBylaw(uint256,uint256,uint256,bool)
         bylawsappSigs[2] = a0_s2; // linkBylaw(bytes4,uint256)
         bylawsappSigs[3] = a0_s3; // setStatusBylaw(uint8,bool,bool)
         bylawsappSigs[4] = a0_s4; // setVotingBylaw(uint256,uint256,uint64,uint64,bool)
         bylawsappSigs[5] = a0_s5; // getAddressBylaw(uint256)
-        bylawsappSigs[6] = a0_s6; // negateIfNeeded(bool,bool)
-        bylawsappSigs[7] = a0_s7; // getBylawType(uint256)
-        bylawsappSigs[8] = a0_s8; // getVotingBylaw(uint256)
-        bylawsappSigs[9] = a0_s9; // setAddressBylaw(address,bool,bool)
-        bylawsappSigs[10] = a0_s10; // canPerformAction(address,address,uint256,bytes)
-        bylawsappSigs[11] = a0_s11; // getBylawNot(uint256)
-        bylawsappSigs[12] = a0_s12; // getCombinatorBylaw(uint256)
-        bylawsappSigs[13] = a0_s13; // bylawEntrypoint(bytes4)
+        bylawsappSigs[6] = a0_s6; // getBylawType(uint256)
+        bylawsappSigs[7] = a0_s7; // getVotingBylaw(uint256)
+        bylawsappSigs[8] = a0_s8; // setAddressBylaw(address,bool,bool)
+        bylawsappSigs[9] = a0_s9; // canPerformAction(address,address,uint256,bytes)
+        bylawsappSigs[10] = a0_s10; // getBylawNot(uint256)
+        bylawsappSigs[11] = a0_s11; // getCombinatorBylaw(uint256)
+        bylawsappSigs[12] = a0_s12; // bylawEntrypoint(bytes4)
         dao.installApp(deployedbylawsapp, bylawsappSigs);
 
         // Proxies are not working on testrpc, that's why for testing no proxy is created
@@ -141,13 +142,13 @@ contract BasicFactory {
         deployedstatusapp.setDAO(address(dao));
         bytes4[] memory statusappSigs = new bytes4[](2);
         statusappSigs[0] = a2_s0; // setEntityStatus(address,uint8)
-        statusappSigs[1] = a2_s1; // entityStatus(address)
+        statusappSigs[1] = a2_s1; // getEntityStatus(address)
         dao.installApp(deployedstatusapp, statusappSigs);
 
         // Proxies are not working on testrpc, that's why for testing no proxy is created
         Application deployedvotingapp = Application(_testrpc ? votingapp : forwarderFactory.createForwarder(votingapp));
         deployedvotingapp.setDAO(address(dao));
-        bytes4[] memory votingappSigs = new bytes4[](12);
+        bytes4[] memory votingappSigs = new bytes4[](11);
         votingappSigs[0] = a3_s0; // voteNay(uint256)
         votingappSigs[1] = a3_s1; // getVoteStatus(uint256)
         votingappSigs[2] = a3_s2; // isVoteCodeValid(address)
@@ -158,8 +159,7 @@ contract BasicFactory {
         votingappSigs[7] = a3_s7; // setValidVoteCode(bytes32,bool)
         votingappSigs[8] = a3_s8; // voteYay(uint256)
         votingappSigs[9] = a3_s9; // isVoteApproved(address,uint256,uint256,uint64,uint64)
-        votingappSigs[10] = a3_s10; // getStatusForVoteAddress(address)
-        votingappSigs[11] = a3_s11; // voteYayAndClose(uint256)
+        votingappSigs[10] = a3_s10; // voteYayAndExecute(uint256)
         dao.installApp(deployedvotingapp, votingappSigs);
 
         return deployedbylawsapp; // first app is bylaws
@@ -176,8 +176,10 @@ contract BasicFactory {
         dao_bylaws.linkBylaw(o0_s2, bylaw_2); // installOrgan(address,bytes4[])
         dao_bylaws.linkBylaw(o0_s3, bylaw_3); // installApp(address,bytes4[])
         dao_bylaws.linkBylaw(o0_s4, bylaw_1); // ceaseToExist()
-        dao_bylaws.linkBylaw(o0_s6, bylaw_2); // removeApp(bytes4[])
-        dao_bylaws.linkBylaw(o0_s7, bylaw_2); // replaceKernel(address)
+        dao_bylaws.linkBylaw(o0_s6, bylaw_2); // updateOrgan(address,bytes4[])
+        dao_bylaws.linkBylaw(o0_s7, bylaw_2); // removeApp(bytes4[])
+        dao_bylaws.linkBylaw(o0_s8, bylaw_2); // replaceKernel(address)
+        dao_bylaws.linkBylaw(o0_s9, bylaw_2); // updateApp(address,bytes4[])
         dao_bylaws.linkBylaw(o1_s5, bylaw_4); // deposit(address,uint256)
     }
 
@@ -197,8 +199,10 @@ contract BasicFactory {
     bytes4 constant o0_s3 = 0x59a565d7; // installApp(address,bytes4[])
     bytes4 constant o0_s4 = 0x5bb95c74; // ceaseToExist()
     bytes4 constant o0_s5 = 0x62a2cf0c; // get(bytes4)
-    bytes4 constant o0_s6 = 0x869effe3; // removeApp(bytes4[])
-    bytes4 constant o0_s7 = 0xcebe30ac; // replaceKernel(address)
+    bytes4 constant o0_s6 = 0x78a54225; // updateOrgan(address,bytes4[])
+    bytes4 constant o0_s7 = 0x869effe3; // removeApp(bytes4[])
+    bytes4 constant o0_s8 = 0xcebe30ac; // replaceKernel(address)
+    bytes4 constant o0_s9 = 0xe6f79926; // updateApp(address,bytes4[])
     // vaultorgan
     bytes4 constant o1_s0 = 0x05b1137b; // transferEther(address,uint256)
     bytes4 constant o1_s1 = 0x1ff0769a; // setTokenBlacklist(address,bool)
@@ -224,14 +228,13 @@ contract BasicFactory {
     bytes4 constant a0_s3 = 0x39d2245b; // setStatusBylaw(uint8,bool,bool)
     bytes4 constant a0_s4 = 0x423c962c; // setVotingBylaw(uint256,uint256,uint64,uint64,bool)
     bytes4 constant a0_s5 = 0x50839d11; // getAddressBylaw(uint256)
-    bytes4 constant a0_s6 = 0x51102b4b; // negateIfNeeded(bool,bool)
-    bytes4 constant a0_s7 = 0x7ac41ef5; // getBylawType(uint256)
-    bytes4 constant a0_s8 = 0x7b0dfa35; // getVotingBylaw(uint256)
-    bytes4 constant a0_s9 = 0x81a08245; // setAddressBylaw(address,bool,bool)
-    bytes4 constant a0_s10 = 0xb18fe4f3; // canPerformAction(address,address,uint256,bytes)
-    bytes4 constant a0_s11 = 0xe289793e; // getBylawNot(uint256)
-    bytes4 constant a0_s12 = 0xe69308d2; // getCombinatorBylaw(uint256)
-    bytes4 constant a0_s13 = 0xea986c0a; // bylawEntrypoint(bytes4)
+    bytes4 constant a0_s6 = 0x7ac41ef5; // getBylawType(uint256)
+    bytes4 constant a0_s7 = 0x7b0dfa35; // getVotingBylaw(uint256)
+    bytes4 constant a0_s8 = 0x81a08245; // setAddressBylaw(address,bool,bool)
+    bytes4 constant a0_s9 = 0xb18fe4f3; // canPerformAction(address,address,uint256,bytes)
+    bytes4 constant a0_s10 = 0xe289793e; // getBylawNot(uint256)
+    bytes4 constant a0_s11 = 0xe69308d2; // getCombinatorBylaw(uint256)
+    bytes4 constant a0_s12 = 0xea986c0a; // bylawEntrypoint(bytes4)
     // ownershipapp
     bytes4 constant a1_s0 = 0x10451468; // sale_closeSale()
     bytes4 constant a1_s1 = 0x1fbc147b; // getTokenSale(uint256)
@@ -257,7 +260,7 @@ contract BasicFactory {
     bytes4 constant a1_s21 = 0xf881a92f; // grantTokens(address,address,uint256)
     // statusapp
     bytes4 constant a2_s0 = 0x6035fa06; // setEntityStatus(address,uint8)
-    bytes4 constant a2_s1 = 0x6b87cdc4; // entityStatus(address)
+    bytes4 constant a2_s1 = 0x7c35ae77; // getEntityStatus(address)
     // votingapp
     bytes4 constant a3_s0 = 0x014396f2; // voteNay(uint256)
     bytes4 constant a3_s1 = 0x0519bb83; // getVoteStatus(uint256)
@@ -269,6 +272,5 @@ contract BasicFactory {
     bytes4 constant a3_s7 = 0x64bfa2f6; // setValidVoteCode(bytes32,bool)
     bytes4 constant a3_s8 = 0x8f328d7a; // voteYay(uint256)
     bytes4 constant a3_s9 = 0xad49224c; // isVoteApproved(address,uint256,uint256,uint64,uint64)
-    bytes4 constant a3_s10 = 0xad5dd1f5; // getStatusForVoteAddress(address)
-    bytes4 constant a3_s11 = 0xcf9883e2; // voteYayAndClose(uint256)
+    bytes4 constant a3_s10 = 0xdb82d1e7; // voteYayAndExecute(uint256)
 }

--- a/contracts/organs/MetaOrgan.sol
+++ b/contracts/organs/MetaOrgan.sol
@@ -61,7 +61,7 @@ contract MetaOrgan is IMetaOrgan, IOrgan, KernelRegistry {
     * @notice Updates application atomically
     * #bylaw voting:75,0
     * @param appAddress new address of the receiving contract for functions
-    * @param sigs should be ordered from 0x0 to 0xffffffff
+    * @param sigs should be ordered from 0x0 to 0xffffffff
     */
     function updateApp(address appAddress, bytes4[] sigs) external {
         deregister(sigs, false);
@@ -69,7 +69,7 @@ contract MetaOrgan is IMetaOrgan, IOrgan, KernelRegistry {
     }
 
     /**
-    * @notice Install organ at address `address`
+    * @notice Install organ at address `organAddress`
     * #bylaw voting:75,0
     * @param organAddress address of the receiving contract for functions
     * @param sigs should be ordered from 0x0 to 0xffffffff

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6578,6 +6578,447 @@
         }
       }
     },
+    "solidity-inspector": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/solidity-inspector/-/solidity-inspector-0.1.0.tgz",
+      "integrity": "sha512-Q1lU4Tx/sGXa5sqHZ02OxvcSAgX7+j1pa04o/yjxMO6/NwqF9FOfm4wwNVP4yQ9vY8j0OFmVqUXfPu0OjezZyw==",
+      "dev": true,
+      "requires": {
+        "solidity-parser": "0.4.0",
+        "yargs": "6.6.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "dev": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "dev": true
+        },
+        "error-ex": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+          "dev": true,
+          "requires": {
+            "is-arrayish": "0.2.1"
+          }
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
+        },
+        "hosted-git-info": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+          "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+          "dev": true
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+          "dev": true
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+          "dev": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+          "dev": true,
+          "requires": {
+            "builtin-modules": "1.1.1"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+          "dev": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "dev": true,
+          "requires": {
+            "invert-kv": "1.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "lodash.assign": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+          "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+          "dev": true
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "2.5.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.4.1",
+            "validate-npm-package-license": "3.0.1"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "dev": true
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "dev": true,
+          "requires": {
+            "lcid": "1.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+          "dev": true,
+          "requires": {
+            "pinkie": "2.0.4"
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "dev": true
+        },
+        "solidity-parser": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/solidity-parser/-/solidity-parser-0.4.0.tgz",
+          "integrity": "sha1-o0PxPac8kWgyeQNGgOgMSR3jQPo=",
+          "dev": true,
+          "requires": {
+            "mocha": "2.5.3",
+            "pegjs": "0.10.0",
+            "yargs": "4.8.1"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "4.8.1",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+              "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+              "dev": true,
+              "requires": {
+                "cliui": "3.2.0",
+                "decamelize": "1.2.0",
+                "get-caller-file": "1.0.2",
+                "lodash.assign": "4.2.0",
+                "os-locale": "1.4.0",
+                "read-pkg-up": "1.0.1",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "1.0.2",
+                "which-module": "1.0.0",
+                "window-size": "0.2.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "2.4.1"
+              }
+            }
+          }
+        },
+        "spdx-correct": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+          "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+          "dev": true,
+          "requires": {
+            "spdx-license-ids": "1.2.2"
+          }
+        },
+        "spdx-expression-parse": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+          "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+          "dev": true
+        },
+        "spdx-license-ids": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+          "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+          "dev": true,
+          "requires": {
+            "spdx-correct": "1.0.2",
+            "spdx-expression-parse": "1.0.4"
+          }
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
+        },
+        "window-size": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+          "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "6.6.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "4.2.1"
+          },
+          "dependencies": {
+            "yargs-parser": {
+              "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+              "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+              "dev": true,
+              "requires": {
+                "camelcase": "3.0.0"
+              }
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+          "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "lodash.assign": "4.2.0"
+          }
+        }
+      }
+    },
     "solidity-parser": {
       "version": "git+https://github.com/sc-forks/solidity-parser.git#6c544bd308fb6d38b2ca7e2adde9a42334221ab0",
       "dev": true,

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "ethereumjs-testrpc": "^4.0.1",
     "handlebars": "^4.0.10",
     "mocha-lcov-reporter": "^1.3.0",
-    "truffle": "^3.4.6",
-    "solidity-coverage": "^0.2.1"
+    "solidity-coverage": "^0.2.1",
+    "solidity-inspector": "^0.1.0",
+    "truffle": "^3.4.6"
   }
 }

--- a/scripts/generate_factory.js
+++ b/scripts/generate_factory.js
@@ -2,7 +2,7 @@ const Handlebars = require('handlebars')
 const fs = require('fs')
 const path = require('path')
 const { signatures } = require('../test/helpers/web3')
-const inspector = require('../../../../../solidity-inspector')
+const inspector = require('solidity-inspector')
 
 const factoryTemplate = path.join(process.cwd(), '../contracts/factories/BasicFactory.sol.tmpl')
 const resultFile = path.join(process.cwd(), '../contracts/factories/BasicFactory.sol')


### PR DESCRIPTION
Fixes #79

Had forgotten to publish our own fork of [`solidity-structure`](https://www.npmjs.com/package/solidity-structure) that `scripts/generate-factory.js` uses to get the needed annotations from source code files.

Running `truffle exec scripts/generate_factory.js` will analyze all Solidity files and generate `BasicFactory.sol` following the a Handlebars template saved at `BasicFactory.sol.tmpl`