### PR TITLE
Index more events

### DIFF
--- a/contracts/apps/basic-governance/IVotingApp.sol
+++ b/contracts/apps/basic-governance/IVotingApp.sol
@@ -5,7 +5,7 @@ contract IVotingOracle {
 }
 
 contract IVotingApp is IVotingOracle {
-    event VoteCreated(uint voteId, address voteAddress);
+    event VoteCreated(uint indexed voteId, address voteAddress);
     event VoteCasted(uint indexed voteId, address voter, bool isYay, uint votes);
     event VoteStateChanged(uint indexed voteId, uint oldState, uint newState);
 

--- a/contracts/apps/bylaws/IBylawsApp.sol
+++ b/contracts/apps/bylaws/IBylawsApp.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.4.13;
 import "../../kernel/IPermissionsOracle.sol";
 
 contract IBylawsApp {
-    event BylawChanged(bytes4 sig, uint bylawType, uint256 bylawId, address changedBy);
+    event BylawChanged(bytes4 sig, uint bylawType, uint256 indexed bylawId, address changedBy);
 
     function linkBylaw(bytes4 _sig, uint _id) external;
 

--- a/contracts/apps/ownership/IOwnershipApp.sol
+++ b/contracts/apps/ownership/IOwnershipApp.sol
@@ -13,11 +13,11 @@ contract IOwnershipSale {
 }
 
 contract IOwnershipApp is ITokenHolderOracle, IOwnershipSale, MiniMeController {
-    event AddedToken(address tokenAddress, uint tokenId);
-    event RemovedToken(address tokenAddress);
-    event ChangedTokenId(address tokenAddress, uint oldTokenId, uint newTokenId);
-    event NewTokenSale(address saleAddress, uint saleId);
-    event TokenSaleClosed(address saleAddress, uint saleId);
+    event AddedToken(address indexed tokenAddress, uint indexed tokenId);
+    event RemovedToken(address indexed tokenAddress);
+    event ChangedTokenId(address indexed tokenAddress, uint indexed oldTokenId, uint indexed newTokenId);
+    event NewTokenSale(address indexed saleAddress, uint indexed saleId);
+    event TokenSaleClosed(address indexed saleAddress, uint indexed saleId);
 
     function addToken(address tokenAddress, uint256 issueAmount, uint128 governanceRights, uint128 economicRights) external;
     function removeToken(address tokenAddress) external;

--- a/contracts/apps/ownership/OwnershipApp.sol
+++ b/contracts/apps/ownership/OwnershipApp.sol
@@ -36,13 +36,6 @@ contract OwnershipApp is Application, IOwnershipApp, Requestor {
     TokenSale[] tokenSales;
     mapping (address => uint) public tokenSaleForAddress;
 
-    event AddedToken(address tokenAddress, uint tokenId);
-    event RemovedToken(address tokenAddress);
-    event ChangedTokenId(address tokenAddress, uint oldTokenId, uint newTokenId);
-
-    event NewTokenSale(address saleAddress, uint saleId);
-    event TokenSaleClosed(address saleAddress, uint saleId);
-
     uint8 constant MAX_TOKENS = 20; // prevent OOGs when tokens are iterated
     uint constant HOLDER_THRESHOLD = 1; // if owns x tokens is considered holder
 

--- a/contracts/apps/status/IStatusApp.sol
+++ b/contracts/apps/status/IStatusApp.sol
@@ -5,7 +5,7 @@ contract IStatusOracle {
 }
 
 contract IStatusApp is IStatusOracle {
-    event EntityStatusChanged(address entity, uint8 status);
+    event EntityStatusChanged(address indexed entity, uint8 indexed status);
 
     function setEntityStatus(address entity, uint8 status) external;
 }

--- a/contracts/factories/ForwarderFactory.sol
+++ b/contracts/factories/ForwarderFactory.sol
@@ -20,5 +20,5 @@ contract ForwarderFactory {
         ForwarderDeployed(fwdContract, target);
     }
 
-    event ForwarderDeployed(address forwarderAddress, address targetContract);
+    event ForwarderDeployed(address forwarderAddress, address indexed targetContract);
 }

--- a/contracts/organs/IVaultOrgan.sol
+++ b/contracts/organs/IVaultOrgan.sol
@@ -2,9 +2,9 @@ pragma solidity ^0.4.11;
 
 contract IVaultOrganEvents {
     event Deposit(address indexed token, address indexed sender, uint256 amount);
-    event Withdraw(address indexed token, address indexed approvedBy, uint256 amount, address recipient);
-    event Recover(address indexed token, address indexed approvedBy, uint256 amount, address recipient);
-    event NewTokenDeposit(address token);
+    event Withdraw(address indexed token, address indexed approvedBy, uint256 amount, address indexed recipient);
+    event Recover(address indexed token, address indexed approvedBy, uint256 amount, address indexed recipient);
+    event NewTokenDeposit(address indexed token);
 }
 
 contract IVaultOrgan is IVaultOrganEvents {


### PR DESCRIPTION
Closes #78.
Adding keyword `indexed` to more variables in different events, this should allow an easier filtering of the different events (for instance, see all actions about a specific token).