### PR TITLE
Call context (dao_msg) now gets passed as part of calldata

### DIFF
--- a/contracts/apps/Application.sol
+++ b/contracts/apps/Application.sol
@@ -4,7 +4,6 @@ import "../organs/IOrgan.sol";
 import "./IApplication.sol";
 
 contract Application is IApplication {
-    IOrgan.DAOMessage dao_msg;
     address public dao;
 
     modifier onlyDAO {
@@ -24,13 +23,7 @@ contract Application is IApplication {
 
     function init() internal {}
 
-    function setDAOMsg(address sender, address token, uint value) onlyDAO {
-        dao_msg.sender = sender;
-        dao_msg.token = token;
-        dao_msg.value = value;
-    }
-
     function getSender() internal returns (address) {
-        return msg.sender == dao ? dao_msg.sender : msg.sender;
+        return msg.sender == dao ? dao_msg().sender : msg.sender;
     }
 }

--- a/contracts/apps/IApplication.sol
+++ b/contracts/apps/IApplication.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.4.13;
 
-contract IApplication {
+import "../misc/DAOMsg.sol";
+
+contract IApplication is DAOMsgReader {
     function init() internal;
-    function setDAOMsg(address sender, address token, uint value);
 }

--- a/contracts/apps/basic-governance/VotingApp.sol
+++ b/contracts/apps/basic-governance/VotingApp.sol
@@ -75,7 +75,7 @@ contract VotingApp is IVotingApp, Application, CodeHelper {
         require(voteForAddress[_voteAddress] == 0); // not allow 2 votings with the same address
 
         Vote storage vote = votes[voteId];
-        vote.voteCreator = dao_msg.sender;
+        vote.voteCreator = dao_msg().sender;
         vote.voteAddress = _voteAddress;
         vote.voteCreatedBlock = getBlockNumber();
         vote.voteStartsBlock = _voteStartsBlock;

--- a/contracts/kernel/Kernel.sol
+++ b/contracts/kernel/Kernel.sol
@@ -11,6 +11,7 @@ pragma solidity ^0.4.13;
 import "./IKernel.sol";
 import "./KernelRegistry.sol";
 import "./IPermissionsOracle.sol";
+import "../misc/DAOMsg.sol";
 
 import "../tokens/EtherToken.sol";
 import "zeppelin/token/ERC20.sol";
@@ -18,7 +19,7 @@ import "zeppelin/token/ERC20.sol";
 import "../organs/IOrgan.sol";
 import "../apps/Application.sol";
 
-contract Kernel is IKernel, IOrgan, KernelRegistry {
+contract Kernel is IKernel, IOrgan, KernelRegistry, DAOMsgEncoder {
     /**
     * @dev MetaOrgan instance keeps saved in its own context.
     * @param _deployedMeta an instance of a MetaOrgan (used for setup)
@@ -113,7 +114,7 @@ contract Kernel is IKernel, IOrgan, KernelRegistry {
     function dispatch(address _sender, address _token, uint256 _value, bytes _payload) internal {
         require(canPerformAction(_sender, _token, _value, _payload));
 
-        vaultDeposit(_token, _value); // deposit tokens that come with the call in the vault
+        vaultDeposit(_sender, _token, _value); // deposit tokens that come with the call in the vault
 
         if (_payload.length == 0) return; // Just receive the tokens
 
@@ -124,17 +125,14 @@ contract Kernel is IKernel, IOrgan, KernelRegistry {
 
         require(target > 0);
 
-        if (isDelegate) {
-            setDAOMsg(DAOMessage(_sender, _token, _value)); // save context so organs can access it
-        } else {
-            Application(target).setDAOMsg(_sender, _token, _value);
-        }
+        bytes memory payloadMsg = calldataWithDAOMsg(_payload, _sender, _token, _value);
 
         assembly {
             let result := 0
+
             switch isDelegate
-            case 1 { result := delegatecall(sub(gas, 10000), target, add(_payload, 0x20), mload(_payload), 0, len) }
-            case 0 { result := call(sub(gas, 10000), target, 0, add(_payload, 0x20), mload(_payload), 0, len) }
+            case 1 { result := delegatecall(sub(gas, 10000), target, add(payloadMsg, 0x20), mload(payloadMsg), 0, len) }
+            case 0 { result := call(sub(gas, 10000), target, 0, add(payloadMsg, 0x20), mload(payloadMsg), 0, len) }
             switch result case 0 { invalid() }
             return(0, len)
         }
@@ -155,14 +153,15 @@ contract Kernel is IKernel, IOrgan, KernelRegistry {
 
     /**
     * @dev Low level deposit of funds to the Vault Organ
+    * @param _sender address that performed the token transfer
     * @param _token address of the token
     * @param _amount amount of the token
     */
-    function vaultDeposit(address _token, uint256 _amount) internal {
+    function vaultDeposit(address _sender, address _token, uint256 _amount) internal {
         var (vaultOrgan,) = get(DEPOSIT_SIG);
         if (_amount == 0 || vaultOrgan == 0) return;
 
-        assert(vaultOrgan.delegatecall(DEPOSIT_SIG, uint256(_token), _amount));
+        assert(vaultOrgan.delegatecall(DEPOSIT_SIG, uint256(_sender), uint256(_token), _amount));
     }
 
     /**
@@ -207,5 +206,5 @@ contract Kernel is IKernel, IOrgan, KernelRegistry {
     address public deployedMeta;
 
     bytes4 constant INSTALL_ORGAN_SIG = bytes4(sha3('installOrgan(address,bytes4[])'));
-    bytes4 constant DEPOSIT_SIG = bytes4(sha3('deposit(address,uint256)'));
+    bytes4 constant DEPOSIT_SIG = bytes4(sha3('deposit(address,address,uint256)'));
 }

--- a/contracts/misc/DAOMsg.sol
+++ b/contracts/misc/DAOMsg.sol
@@ -1,0 +1,81 @@
+pragma solidity ^0.4.13;
+
+contract DAOMsgEncoder {
+    /**
+     * @dev Package encoding: 0th to 24th byte are all 0s (padding so entire package is 32*3 bytes) 24 to 44 bytes sender, 44 to 64 token, 64 to 96 value
+     * @param _sender Address of the sender of the DAO message (Encoded from byte 24th to 44th)
+     * @param _token Address of the token used to send the message (Encoded from byte 44th to 64th)
+     * @param _value Value of token transfered in call
+     * @return bytes payload to be appended to calldata for a DAO call
+     */
+    function calldataWithDAOMsg(bytes data, address _sender, address _token, uint _value) constant returns (bytes payload) {
+        payload = new bytes(data.length + 96);
+        uint dataptr; uint payloadptr;
+        assembly { dataptr := add(data, 0x20) payloadptr := add(payload, 0x20) }
+        memcpy(payloadptr, dataptr, data.length);
+        encodeDAOMsg(payloadptr + data.length, _sender, _token, _value);
+    }
+
+    function encodeDAOMsg(uint payloadptr, address _sender, address _token, uint _value) internal {
+        assembly {
+            mstore(add(payloadptr, 0x40), _value) // save value in last slot
+            mstore(add(payloadptr, 0x20), _token) // save token address before value, will leave first 12 bytes as 0s
+            mstore(add(payloadptr, sub(0x20, 0x14)), _sender) // save sender on top of _token 0s
+        }
+    }
+
+    // From @arachnid's stringutils https://github.com/Arachnid/solidity-stringutils
+    function memcpy(uint dest, uint src, uint len) private {
+        // Copy word-length chunks while possible
+        for(; len >= 32; len -= 32) {
+            assembly {
+                mstore(dest, mload(src))
+            }
+            dest += 32;
+            src += 32;
+        }
+
+        // Copy remaining bytes
+        uint mask = 256 ** (32 - len) - 1;
+        assembly {
+            let srcpart := and(mload(src), not(mask))
+            let destpart := and(mload(dest), mask)
+            mstore(dest, or(destpart, srcpart))
+        }
+    }
+
+}
+
+contract DAOMsgReader {
+    struct DAOMsg {
+        address sender;
+        address token;
+        uint value;
+        bytes data;
+    }
+
+    function dao_msg() internal returns (DAOMsg memory) {
+        address sender;
+        address token;
+        uint value;
+        uint padding;
+        bytes memory data;
+
+        assembly {
+            padding := calldataload(sub(calldatasize(), 0x60))
+            sender := calldataload(sub(calldatasize(), sub(0x60, 0x0c)))
+            token := calldataload(sub(calldatasize(), 0x40))
+            value := calldataload(sub(calldatasize(), 0x20))
+
+            let size := sub(calldatasize(), 0x60) // size of data without payload
+            data := mload(0x40) // get free memory pointer
+            mstore(0x40, add(data, and(add(add(size, 0x20), 0x1f), not(0x1f)))) // save next free memory pointer
+
+            mstore(data, size) // store size of the bytes array
+            calldatacopy(add(data, 0x20), 0, size)
+        }
+
+        // assert(padding >> 8 * 8 == 0); // assert package was correctly padded, first 24 bytes should be 0
+        return DAOMsg(sender, token, value, data);
+    }
+}

--- a/contracts/misc/DAOMsg.sol
+++ b/contracts/misc/DAOMsg.sol
@@ -8,7 +8,7 @@ contract DAOMsgEncoder {
      * @param _value Value of token transfered in call
      * @return bytes payload to be appended to calldata for a DAO call
      */
-    function calldataWithDAOMsg(bytes data, address _sender, address _token, uint _value) constant returns (bytes payload) {
+    function calldataWithDAOMsg(bytes data, address _sender, address _token, uint _value) internal constant returns (bytes payload) {
         payload = new bytes(data.length + 96);
         uint dataptr; uint payloadptr;
         assembly { dataptr := add(data, 0x20) payloadptr := add(payload, 0x20) }
@@ -75,7 +75,7 @@ contract DAOMsgReader {
             calldatacopy(add(data, 0x20), 0, size)
         }
 
-        // assert(padding >> 8 * 8 == 0); // assert package was correctly padded, first 24 bytes should be 0
+        assert(padding >> 8 * 8 == 0); // assert package was correctly padded, first 24 bytes should be 0
         return DAOMsg(sender, token, value, data);
     }
 }

--- a/contracts/misc/DAOMsg.sol
+++ b/contracts/misc/DAOMsg.sol
@@ -3,17 +3,18 @@ pragma solidity ^0.4.13;
 contract DAOMsgEncoder {
     /**
      * @dev Package encoding: 0th to 24th byte are all 0s (padding so entire package is 32*3 bytes) 24 to 44 bytes sender, 44 to 64 token, 64 to 96 value
+     * @param _data Original calldata to append dao_msg packet
      * @param _sender Address of the sender of the DAO message (Encoded from byte 24th to 44th)
      * @param _token Address of the token used to send the message (Encoded from byte 44th to 64th)
      * @param _value Value of token transfered in call
      * @return bytes payload to be appended to calldata for a DAO call
      */
-    function calldataWithDAOMsg(bytes data, address _sender, address _token, uint _value) internal constant returns (bytes payload) {
-        payload = new bytes(data.length + 96);
+    function calldataWithDAOMsg(bytes _data, address _sender, address _token, uint _value) internal constant returns (bytes payload) {
+        payload = new bytes(_data.length + 96);
         uint dataptr; uint payloadptr;
-        assembly { dataptr := add(data, 0x20) payloadptr := add(payload, 0x20) }
-        memcpy(payloadptr, dataptr, data.length);
-        encodeDAOMsg(payloadptr + data.length, _sender, _token, _value);
+        assembly { dataptr := add(_data, 0x20) payloadptr := add(payload, 0x20) }
+        memcpy(payloadptr, dataptr, _data.length);
+        encodeDAOMsg(payloadptr + _data.length, _sender, _token, _value);
     }
 
     function encodeDAOMsg(uint payloadptr, address _sender, address _token, uint _value) internal {

--- a/contracts/organs/IOrgan.sol
+++ b/contracts/organs/IOrgan.sol
@@ -1,30 +1,7 @@
 pragma solidity ^0.4.11;
 
 import "../dao/DAOStorage.sol";
+import "../misc/DAOMsg.sol";
 
-contract IOrgan is DAOStorage {
-    // dao_msg storage keys
-    bytes32 constant SENDER_KEY = sha3(0x00, 0x02, 0x00);
-    bytes32 constant TOKEN_KEY = sha3(0x00, 0x02, 0x01);
-    bytes32 constant VALUE_KEY = sha3(0x00, 0x02, 0x02);
-
-    struct DAOMessage {
-        address sender;
-        address token;
-        uint256 value;
-    }
-
-    function dao_msg() internal returns (DAOMessage) {
-        return DAOMessage(
-            address(storageGet(SENDER_KEY)),
-            address(storageGet(TOKEN_KEY)),
-            storageGet(VALUE_KEY)
-        );
-    }
-
-    function setDAOMsg(DAOMessage dao_msg) internal {
-        storageSet(SENDER_KEY, uint256(dao_msg.sender));
-        storageSet(TOKEN_KEY, uint256(dao_msg.token));
-        storageSet(VALUE_KEY, uint256(dao_msg.value));
-    }
+contract IOrgan is DAOStorage, DAOMsgReader {
 }

--- a/contracts/organs/IVaultOrgan.sol
+++ b/contracts/organs/IVaultOrgan.sol
@@ -8,7 +8,7 @@ contract IVaultOrganEvents {
 }
 
 contract IVaultOrgan is IVaultOrganEvents {
-    function deposit(address _token, uint256 _amount) external payable;
+    function deposit(address _sender, address _token, uint256 _amount) external payable;
     function getTokenBalance(address _token) constant returns (uint256);
 
     function transfer(address _token, address _to, uint256 _amount) external;

--- a/contracts/organs/VaultOrgan.sol
+++ b/contracts/organs/VaultOrgan.sol
@@ -30,6 +30,7 @@ contract VaultOrgan is IVaultOrgan, SafeMath, IOrgan {
     external
     payable
     {
+        require(msg.data.length == 4 + 3 * 32); // assure call doesn't have DAOmsg (cannot be called externally)
         if (_amount == 0)
             return;
         if (_token == 0 && msg.value == _amount)

--- a/contracts/organs/VaultOrgan.sol
+++ b/contracts/organs/VaultOrgan.sol
@@ -20,12 +20,12 @@ contract VaultOrgan is IVaultOrgan, SafeMath, IOrgan {
     uint constant MAX_HALT = 7 days; // can be prorrogated during halt
 
     /**
-    * @dev deposit is not reachable on purpose using normal dispatch route
+    * @dev deposit is not reachable on purpose using normal dispatch route (cannot use dao_msg())
     * #bylaw address:0
     * @param _token Address for the token being deposited in call
     * @param _amount Token units being deposited
     */
-    function deposit(address _token, uint256 _amount)
+    function deposit(address _sender, address _token, uint256 _amount)
     check_blacklist(_token)
     external
     payable
@@ -53,7 +53,7 @@ contract VaultOrgan is IVaultOrgan, SafeMath, IOrgan {
         assert(newBalance <= ERC20(token).balanceOf(this));
 
         setTokenBalance(token, newBalance);
-        Deposit(token, dao_msg().sender, _amount);
+        Deposit(token, _sender, _amount);
     }
 
     /**

--- a/test/dao_msg.js
+++ b/test/dao_msg.js
@@ -1,0 +1,81 @@
+const assertThrow = require('./helpers/assertThrow');
+var DAO = artifacts.require('DAO');
+var MetaOrgan = artifacts.require('MetaOrgan')
+var Kernel = artifacts.require('Kernel')
+var VaultOrgan = artifacts.require('VaultOrgan')
+var EtherToken = artifacts.require('EtherToken')
+var DAOMsgOrgan = artifacts.require('DAOMsgOrgan')
+var DAOMsgApp = artifacts.require('DAOMsgApp')
+var StandardTokenPlus = artifacts.require('./helpers/StandardTokenPlus')
+var Standard23Token = artifacts.require('./helpers/Standard23Token')
+
+var IOrgan = artifacts.require('IOrgan')
+
+const { installOrgans, installApps } = require('./helpers/installer')
+const { sign } = require('./helpers/web3')
+
+const createDAO = () => DAO.new(Kernel.address)
+
+const zerothAddress = '0x0000000000000000000000000000000000000000'
+const randomAddress = '0x0000000000000000000000000000000000001234'
+const updateAddress = '0x0000000000000000000000000000000000004321'
+
+contract('DAO msg', accounts => {
+  let dao, metadao, kernel, vault, tester = {}
+
+  beforeEach(async () => {
+    dao = await createDAO()
+    metadao = MetaOrgan.at(dao.address)
+    kernel = Kernel.at(dao.address)
+
+    await installOrgans(metadao, [MetaOrgan, VaultOrgan])
+
+    vault = VaultOrgan.at(dao.address)
+    await vault.setupEtherToken()
+  })
+
+  const tests = function () {
+      it('for vanilla call', async () => {
+          await tester.assertDaoMsg(accounts[0], zerothAddress, 0)
+      })
+
+      it('for value transfering calls', async () => {
+          await tester.assertDaoMsg(accounts[0], zerothAddress, 1, { value: 1 })
+      })
+
+      it('for token calls', async () => {
+          const token = await StandardTokenPlus.new()
+          const data = tester.assertDaoMsg.request(accounts[0], token.address, 10).params[0].data
+
+          await token.approveAndCall(dao.address, 10, data)
+      })
+
+      it('throws for incorrect params', async () => {
+          try {
+            await tester.assertDaoMsg(accounts[1], zerothAddress, 0)
+          } catch (error) {
+            return assertThrow(error)
+          }
+          assert.fail('should have thrown before')
+      })
+  }
+
+  context('when dispatching organ calls has correct dao_msg', () => {
+      beforeEach(async () => {
+          await installOrgans(metadao, [DAOMsgOrgan])
+          tester = DAOMsgOrgan.at(dao.address)
+      })
+
+      context('', tests)
+  })
+
+  context('when dispatching app calls has correct dao_msg', () => {
+      let tester = {}
+      beforeEach(async () => {
+          await installApps(metadao, [DAOMsgApp])
+          tester = DAOMsgOrgan.at(dao.address)
+      })
+
+      context('', tests)
+  })
+})

--- a/test/dao_vault.js
+++ b/test/dao_vault.js
@@ -32,6 +32,17 @@ contract('Vault', accounts => {
     mockedOrgan = MockedOrgan.at(dao.address)
   })
 
+  it('throws when calling deposit() externally', async () => {
+      const token = await StandardTokenPlus.new()
+      await token.transfer(dao.address, 10)
+      try {
+        await vault.deposit(randomAddress, token.address, 10)
+      } catch (error) {
+        return assertThrow(error)
+      }
+      assert.fail('should have thrown before')
+  })
+
   context('when receiving ether', () => {
     let token = {}
     beforeEach(async () => {

--- a/test/helpers/DAOMsgOrgan.sol
+++ b/test/helpers/DAOMsgOrgan.sol
@@ -1,0 +1,24 @@
+pragma solidity ^0.4.13;
+
+import "../../contracts/apps/Application.sol";
+import "../../contracts/organs/IOrgan.sol";
+
+contract DAOMsgOrgan is IOrgan {
+    function assertDaoMsg(address sender, address token, uint256 value) payable {
+        require(dao_msg().sender == sender);
+        require(dao_msg().token == token);
+        require(dao_msg().value == value);
+        require(dao_msg().data.length == 4 + 32 * 3);
+    }
+}
+
+contract DAOMsgApp is Application {
+    function DAOMsgApp() Application(0) {}
+        
+    function assertDaoMsg(address sender, address token, uint256 value) payable {
+        require(dao_msg().sender == sender);
+        require(dao_msg().token == token);
+        require(dao_msg().value == value);
+        require(dao_msg().data.length == 4 + 32 * 3);
+    }
+}


### PR DESCRIPTION
Fixes #30 

### What is `dao_msg`

`dao_msg` is the form of passing context about the call to DAO components (organs and apps). It is similar to Solidity's `msg.x` which cannot be trusted given that calls to the DAO can be made through multiple entrypoints and get routed through the kernel.

`dao_msg` exposes the true`sender` of the transaction, the `token` the transaction was made with and its `value`.

### How it used to work

Prior to this PR, right before dispatching the call to the specific DAO component, the dao_msg data was saved in storage (in the case of organs, in DAO storage and in the case of apps, a call to the app was made and the app saved it). This approach was fairly expensive gas wise (3 extra sstore's per call) and was also vulnerable to race conditions in case a call reentered in the DAO as explained in #30 

### Solution: send call context as part of the calldata

It is possible to append more data after the 'normal' calldata for a function call. Solidity will only parse the 'normal' data for the call but the bytes appended after that can be accessed too.

Now before dispatching a call to an organ or app, the dao_msg packet gets appended to the original data payload, and that new payload gets dispatched. 

Apps or organs work exactly the same, but now when they access `dao_msg()`, the extra bytes in the call data get parsed and returned. As the `dao_msg` context is part of the call context, it is not vulnerable anymore to it changing in case of reentrancy!
 
### Implementation

[`misc/DAOMsg.sol`](https://github.com/aragon/aragon-core/compare/dao_msg?expand=1#diff-82be908ec5ec2c25eaf58b5a5a1e1edc) implements encoding and decoding `dao_msg()`.

The data appended to the calldata has the following format:

Byte 0 to 24th: all `0`. It is used as a padding to make the package be exactly 3 32 byte slots.
Byte 24 to 44th: `sender` address.
Byte 44 to 64th: `token` address
Byte 64 to 96th: `value` of token.