### PR TITLE
Added token whitelist [Draft]

### DIFF
--- a/contracts/apps/bylaws/BylawsApp.sol
+++ b/contracts/apps/bylaws/BylawsApp.sol
@@ -131,6 +131,9 @@ contract BylawsApp is IBylawsApp, Application {
         bytes data
     ) constant returns (bool)
     {
+        if(!isTokenWhitelisted[token] || token != 0)
+           return false
+
         return canPerformAction(
             getSig(data),
             sender,

--- a/contracts/apps/bylaws/BylawsApp.sol
+++ b/contracts/apps/bylaws/BylawsApp.sol
@@ -55,6 +55,8 @@ contract BylawsApp is IBylawsApp, Application {
     Bylaw[] bylaws;
     mapping (bytes4 => uint) public bylawEntrypoint;
 
+    mapping (address => bool) public isTokenWhitelisted;
+
     uint constant PCT_BASE = 10 ** 18;
 
     function BylawsApp(address dao)
@@ -101,6 +103,18 @@ contract BylawsApp is IBylawsApp, Application {
             getSender()
         );
     }
+
+    /**
+    * @dev Change the whitelist status of a token
+    * @ param token address The token to whitelist
+    * @ _whitelist bool Desired status of token
+    */
+    function setTokenWhitelist(address token, bool _whitelist)
+    onlyDAO
+    public
+    {
+      isTokenWhitelisted[token] = _whitelist;
+   }
 
     /**
     * @dev Implements Permissions Oracle compatibility so it can be called from Kernel

--- a/contracts/apps/bylaws/BylawsApp.sol
+++ b/contracts/apps/bylaws/BylawsApp.sol
@@ -113,8 +113,8 @@ contract BylawsApp is IBylawsApp, Application {
     onlyDAO
     public
     {
-      isTokenWhitelisted[token] = _whitelist;
-   }
+        isTokenWhitelisted[token] = _whitelist;
+    }
 
     /**
     * @dev Implements Permissions Oracle compatibility so it can be called from Kernel
@@ -131,8 +131,9 @@ contract BylawsApp is IBylawsApp, Application {
         bytes data
     ) constant returns (bool)
     {
-        if(!isTokenWhitelisted[token] || token != 0)
-           return false
+        if (!isTokenWhitelisted[token] && token != 0)
+            return false;
+
 
         return canPerformAction(
             getSig(data),

--- a/contracts/kernel/Kernel.sol
+++ b/contracts/kernel/Kernel.sol
@@ -88,7 +88,7 @@ contract Kernel is IKernel, IOrgan, KernelRegistry {
     function receiveApproval(address _sender, uint256 _value, address _token, bytes _data) public {
         // TODO: Check whether msg.sender token is trusted
         assert(ERC20(_token).transferFrom(_sender, address(this), _value));
-        dispatch(_sender, _token, _value, _data);
+        dispatch(_token == msg.sender ? _sender : msg.sender, _token, _value, _token == msg.sender ? _data : new bytes(0));
     }
 
     /**
@@ -111,11 +111,12 @@ contract Kernel is IKernel, IOrgan, KernelRegistry {
     * @return - the underlying call returns (upto RETURN_MEMORY_SIZE memory)
     */
     function dispatch(address _sender, address _token, uint256 _value, bytes _payload) internal {
-        require(canPerformAction(_sender, _token, _value, _payload));
 
         vaultDeposit(_token, _value); // deposit tokens that come with the call in the vault
 
         if (_payload.length == 0) return; // Just receive the tokens
+
+        require(canPerformAction(_sender, _token, _value, _payload));
 
         bytes4 sig;
         assembly { sig := mload(add(_payload, 0x20)) }

--- a/contracts/kernel/Kernel.sol
+++ b/contracts/kernel/Kernel.sol
@@ -136,7 +136,7 @@ contract Kernel is IKernel, IOrgan, KernelRegistry {
         vaultDeposit(_token, _value); // deposit tokens that come with the call in the vault
 
 
-        if (isPayloadEmpty(_payload))
+        if (_payload.length == 0)
           return; // Just receive the tokens
 
         require(canPerformAction(_sender, _token, _value, _payload));
@@ -234,18 +234,6 @@ contract Kernel is IKernel, IOrgan, KernelRegistry {
 
     function getPermissionsOracle() constant returns (address) {
         return address(storageGet(sha3(0x01, 0x03)));
-    }
-
-    function isPayloadEmpty(bytes payload) internal returns (bool) {
-        if (payload.length == 0)
-          return true;
-
-        for (uint i = 0; i < 5; i++) {
-          if (payload[i] != 0x00) {
-            return false;
-          }
-        }
-        return true;
     }
 
     address public deployedMeta;

--- a/test/helpers/Standard23Token.sol
+++ b/test/helpers/Standard23Token.sol
@@ -38,11 +38,11 @@ contract Standard23Token is ERC23, StandardToken {
   }
 
   function transfer(address _to, uint _value) returns (bool success) {
-    return transfer(_to, _value, new bytes(32));
+    return transfer(_to, _value, new bytes(0));
   }
 
   function transferFrom(address _from, address _to, uint _value) returns (bool success) {
-    return transferFrom(_from, _to, _value, new bytes(32));
+    return transferFrom(_from, _to, _value, new bytes(0));
   }
 
   //function that is called when transaction target is a contract

--- a/test/integration_bylaws.js
+++ b/test/integration_bylaws.js
@@ -10,6 +10,7 @@ var ActionsOrgan = artifacts.require('ActionsOrgan')
 var VaultOrgan = artifacts.require('VaultOrgan')
 var Vote = artifacts.require('Vote')
 var BylawOracleMock = artifacts.require('mocks/BylawOracleMock')
+var Standart23Token = artifacts.require('mocks/Standard23Token')
 
 var Kernel = artifacts.require('Kernel')
 
@@ -47,6 +48,35 @@ contract('Bylaws', accounts => {
 
       assert.equal(await dao.getKernel(), randomAddress, 'Kernel should have been changed')
   })
+
+  context('adding token whitelist', () => {
+
+     var token, tokenAddress;
+
+     beforeEach(async () => {
+        token = await Standart23Token.new({from: accounts[3]});
+        tokenAddress = await token.address;
+     })
+
+     it('correctly sets an whitlisted token', async () => {
+       await bylawsApp.setTokenWhitelist(tokenAddress, true, {from: dao.address});
+       assert.isTrue(await bylawsApp.isTokenWhitelisted(tokenAddress));
+       await bylawsApp.setTokenWhitelist(tokenAddress, false, {from: dao.address});
+       assert.isFalse(await bylawsApp.isTokenWhitelisted(tokenAddress));
+     });
+
+     it('allows non list token deposit', async () => {
+        await token.transfer(dao.address, 10, {from: accounts[3]});
+        let balance = await token.balanceOf(dao.address)
+        assert.equal(balance.toNumber(), 10);
+     });
+
+     it('blocks non listed token exectuion', async () => {
+        //await token.transfer(dao.address, 10, 'executionData', {from: accounts[3]});
+     });
+
+     it('allows listed token execution', async () => {});
+ })
 
   context('adding address bylaw', () => {
     beforeEach(async () => {


### PR DESCRIPTION
Hello @izqui 

Here's the current state of the contracts. I've done this in different forms but never managed to make it work.

All tests(introduced by me) are failing for different reasons:

`'correctly sets an whitlisted token'` is failing with: `could not unlock signer account`. Which I presume is because I'm trying to send from the dao address, but I could not go around this since the function itself is protected with `onlyDao` modifier.

`allows non listed token deposit` throws somewhere. I honestly don't know why.

The last two `blocks non listed token exectuion` and ` allows listed token execution` are incomplete, because I'm getting `Invalid number of arguments to Solidity function`, even though there are two signatures of the `transfer` function in `Standard23Token` and one of them takes 3 arguments.

Thanks for the help and sorry for the trouble in such a simple issue!

Closes #72 