### PR TITLE
Change bylaw ids from incremental integers to hashes and other security measures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage/
 coverageEnv/
 coverage.json
 scTopics
+functions.csv

--- a/contracts/apps/Application.sol
+++ b/contracts/apps/Application.sol
@@ -7,7 +7,7 @@ contract Application is IApplication {
     address public dao;
 
     modifier onlyDAO {
-        require(dao == 0 || msg.sender == dao);
+        require(msg.sender == dao);
         _;
     }
 
@@ -15,8 +15,12 @@ contract Application is IApplication {
         setDAO(newDAO);
     }
 
-    function setDAO(address newDAO) onlyDAO {
+    /**
+    * @dev setDAO can be called outside of constructor for allowing Forwarder contracts
+    */
+    function setDAO(address newDAO) {
         if (newDAO == 0) return;
+        require(dao == 0); // bypassing of all bylaws can happen if changing dao reference for app
         dao = newDAO;
         init();
     }

--- a/contracts/apps/basic-governance/IVotingApp.sol
+++ b/contracts/apps/basic-governance/IVotingApp.sol
@@ -5,7 +5,7 @@ contract IVotingOracle {
 }
 
 contract IVotingApp is IVotingOracle {
-    event VoteCreated(uint voteId, address voteAddress);
+    event VoteCreated(uint indexed voteId, address voteAddress);
     event VoteCasted(uint indexed voteId, address voter, bool isYay, uint votes);
     event VoteStateChanged(uint indexed voteId, uint oldState, uint newState);
 

--- a/contracts/apps/bylaws/BylawsApp.sol
+++ b/contracts/apps/bylaws/BylawsApp.sol
@@ -132,10 +132,14 @@ contract BylawsApp is IBylawsApp, Application {
         uint id = uint(sha3(msg.sig, _statusNeeded, _isTokenHolderStatus, _not));
         Bylaw storage bylaw = bylaws[id];
 
+        require(!bylaw.exists);
+
         bylaw.bylawType = _isTokenHolderStatus ? BylawType.TokenHolder : BylawType.Status;
         bylaw.status = _statusNeeded;
         bylaw.not = _not;
         bylaw.exists = true;
+
+        NewBylaw(id);
 
         return id;
     }
@@ -151,10 +155,14 @@ contract BylawsApp is IBylawsApp, Application {
         uint id = uint(sha3(msg.sig, _addr, _isOracle, _not));
         Bylaw storage bylaw = bylaws[id];
 
+        require(!bylaw.exists);
+
         bylaw.bylawType = _isOracle ? BylawType.Oracle : BylawType.Address;
         bylaw.addr = _addr;
         bylaw.not = _not;
         bylaw.exists = true;
+
+        NewBylaw(id);
 
         return id;
     }
@@ -178,6 +186,7 @@ contract BylawsApp is IBylawsApp, Application {
         uint id = uint(sha3(msg.sig, _supportPct, _minQuorumPct, _minDebateTime, _minVotingTime, _not));
         Bylaw storage bylaw = bylaws[id];
 
+        require(!bylaw.exists);
         require(_supportPct > 0 && _supportPct <= PCT_BASE); // dont allow weird cases
 
         bylaw.bylawType = BylawType.Voting;
@@ -187,6 +196,8 @@ contract BylawsApp is IBylawsApp, Application {
         bylaw.voting.minVotingTime = _minVotingTime;
         bylaw.not = _not;
         bylaw.exists = true;
+
+        NewBylaw(id);
 
         return id;
     }
@@ -210,6 +221,7 @@ contract BylawsApp is IBylawsApp, Application {
     {
         uint id = uint(sha3(msg.sig, _combinatorType, _leftBylawId, _rightBylawId, _not));
         Bylaw storage bylaw = bylaws[id];
+        require(!bylaw.exists);
         require(_leftBylawId != _rightBylawId && _rightBylawId > 0);
 
         bylaw.bylawType = BylawType.Combinator;
@@ -218,6 +230,8 @@ contract BylawsApp is IBylawsApp, Application {
         bylaw.combinator.rightBylawId = _rightBylawId;
         bylaw.not = _not;
         bylaw.exists = true;
+
+        NewBylaw(id);
 
         return id;
     }

--- a/contracts/apps/bylaws/BylawsApp.sol
+++ b/contracts/apps/bylaws/BylawsApp.sol
@@ -30,6 +30,7 @@ contract BylawsApp is IBylawsApp, Application {
         BylawType bylawType;
 
         bool not; // reverse logic. makes bylaw pass if it was false
+        bool exists;
 
         // a bylaw can be one of these types
         uint8 status; // For status type
@@ -52,7 +53,7 @@ contract BylawsApp is IBylawsApp, Application {
         uint256 rightBylawId;
     }
 
-    Bylaw[] bylaws;
+    mapping (uint => Bylaw) bylaws;
     mapping (bytes4 => uint) public bylawEntrypoint;
 
     uint constant PCT_BASE = 10 ** 18;
@@ -63,20 +64,14 @@ contract BylawsApp is IBylawsApp, Application {
     }
 
     function init() internal {
-        var (id, bylaw) = newBylaw(); // so index is 1 for first legit bylaw
-        assert(id == 0);
+        Bylaw storage bylaw = bylaws[0];
 
         // unassigned bylaws will use bylaw 0 as its own
         // by default allow calls from any non-zero address (aka every address)
+        // TODO: Setup sane default bylaw
         bylaw.bylawType = BylawType.Address;
         bylaw.addr = 0;
         bylaw.not = true;
-    }
-
-    function newBylaw() internal returns (uint id, Bylaw storage newBylaw) {
-        id = bylaws.length;
-        bylaws.length++;
-        newBylaw = bylaws[id];
     }
 
     /**
@@ -134,11 +129,13 @@ contract BylawsApp is IBylawsApp, Application {
     * @return uint bylaw id
     */
     function setStatusBylaw(uint8 _statusNeeded, bool _isTokenHolderStatus, bool _not) external returns (uint) {
-        var (id, bylaw) = newBylaw();
+        uint id = uint(sha3(msg.sig, _statusNeeded, _isTokenHolderStatus, _not));
+        Bylaw storage bylaw = bylaws[id];
 
         bylaw.bylawType = _isTokenHolderStatus ? BylawType.TokenHolder : BylawType.Status;
         bylaw.status = _statusNeeded;
         bylaw.not = _not;
+        bylaw.exists = true;
 
         return id;
     }
@@ -151,11 +148,13 @@ contract BylawsApp is IBylawsApp, Application {
     * @return uint bylaw id
     */
     function setAddressBylaw(address _addr, bool _isOracle, bool _not) external returns (uint) {
-        var (id, bylaw) = newBylaw();
+        uint id = uint(sha3(msg.sig, _addr, _isOracle, _not));
+        Bylaw storage bylaw = bylaws[id];
 
         bylaw.bylawType = _isOracle ? BylawType.Oracle : BylawType.Address;
         bylaw.addr = _addr;
         bylaw.not = _not;
+        bylaw.exists = true;
 
         return id;
     }
@@ -176,7 +175,8 @@ contract BylawsApp is IBylawsApp, Application {
         uint64 _minVotingTime,
         bool _not
     ) external returns (uint) {
-        var (id, bylaw) = newBylaw();
+        uint id = uint(sha3(msg.sig, _supportPct, _minQuorumPct, _minDebateTime, _minVotingTime, _not));
+        Bylaw storage bylaw = bylaws[id];
 
         require(_supportPct > 0 && _supportPct <= PCT_BASE); // dont allow weird cases
 
@@ -186,6 +186,7 @@ contract BylawsApp is IBylawsApp, Application {
         bylaw.voting.minDebateTime = _minDebateTime;
         bylaw.voting.minVotingTime = _minVotingTime;
         bylaw.not = _not;
+        bylaw.exists = true;
 
         return id;
     }
@@ -207,7 +208,8 @@ contract BylawsApp is IBylawsApp, Application {
     existing_bylaw(_leftBylawId)
     external returns (uint)
     {
-        var (id, bylaw) = newBylaw();
+        uint id = uint(sha3(msg.sig, _combinatorType, _leftBylawId, _rightBylawId, _not));
+        Bylaw storage bylaw = bylaws[id];
         require(_leftBylawId != _rightBylawId && _rightBylawId > 0);
 
         bylaw.bylawType = BylawType.Combinator;
@@ -401,7 +403,7 @@ contract BylawsApp is IBylawsApp, Application {
 
     modifier existing_bylaw(uint bylawId) {
         require(bylawId > 0);
-        require(bylawId < bylaws.length);
+        require(bylaws[bylawId].exists);
         _;
     }
 }

--- a/contracts/apps/bylaws/BylawsApp.sol
+++ b/contracts/apps/bylaws/BylawsApp.sol
@@ -217,6 +217,7 @@ contract BylawsApp is IBylawsApp, Application {
         bylaw.combinator.leftBylawId = _leftBylawId;
         bylaw.combinator.rightBylawId = _rightBylawId;
         bylaw.not = _not;
+        bylaw.exists = true;
 
         return id;
     }

--- a/contracts/apps/bylaws/IBylawsApp.sol
+++ b/contracts/apps/bylaws/IBylawsApp.sol
@@ -3,7 +3,8 @@ pragma solidity ^0.4.13;
 import "../../kernel/IPermissionsOracle.sol";
 
 contract IBylawsApp {
-    event BylawChanged(bytes4 sig, uint bylawType, uint256 indexed bylawId, address changedBy);
+    event NewBylaw(uint bylawId);
+    event BylawChanged(bytes4 sig, uint bylawType, uint256 bylawId, address changedBy);
 
     function linkBylaw(bytes4 _sig, uint _id) external;
 

--- a/contracts/apps/bylaws/IBylawsApp.sol
+++ b/contracts/apps/bylaws/IBylawsApp.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.4.13;
 import "../../kernel/IPermissionsOracle.sol";
 
 contract IBylawsApp {
-    event BylawChanged(bytes4 sig, uint bylawType, uint256 bylawId, address changedBy);
+    event BylawChanged(bytes4 sig, uint bylawType, uint256 indexed bylawId, address changedBy);
 
     function linkBylaw(bytes4 _sig, uint _id) external;
 

--- a/contracts/apps/ownership/IOwnershipApp.sol
+++ b/contracts/apps/ownership/IOwnershipApp.sol
@@ -13,11 +13,11 @@ contract IOwnershipSale {
 }
 
 contract IOwnershipApp is ITokenHolderOracle, IOwnershipSale, MiniMeController {
-    event AddedToken(address tokenAddress, uint tokenId);
-    event RemovedToken(address tokenAddress);
-    event ChangedTokenId(address tokenAddress, uint oldTokenId, uint newTokenId);
-    event NewTokenSale(address saleAddress, uint saleId);
-    event TokenSaleClosed(address saleAddress, uint saleId);
+    event AddedToken(address indexed tokenAddress, uint indexed tokenId);
+    event RemovedToken(address indexed tokenAddress);
+    event ChangedTokenId(address indexed tokenAddress, uint indexed oldTokenId, uint indexed newTokenId);
+    event NewTokenSale(address indexed saleAddress, uint indexed saleId);
+    event TokenSaleClosed(address indexed saleAddress, uint indexed saleId);
 
     function addToken(address tokenAddress, uint256 issueAmount, uint128 governanceRights, uint128 economicRights) external;
     function removeToken(address tokenAddress) external;

--- a/contracts/apps/ownership/OwnershipApp.sol
+++ b/contracts/apps/ownership/OwnershipApp.sol
@@ -36,13 +36,6 @@ contract OwnershipApp is Application, IOwnershipApp, Requestor {
     TokenSale[] tokenSales;
     mapping (address => uint) public tokenSaleForAddress;
 
-    event AddedToken(address tokenAddress, uint tokenId);
-    event RemovedToken(address tokenAddress);
-    event ChangedTokenId(address tokenAddress, uint oldTokenId, uint newTokenId);
-
-    event NewTokenSale(address saleAddress, uint saleId);
-    event TokenSaleClosed(address saleAddress, uint saleId);
-
     uint8 constant MAX_TOKENS = 20; // prevent OOGs when tokens are iterated
     uint constant HOLDER_THRESHOLD = 1; // if owns x tokens is considered holder
 

--- a/contracts/apps/status/IStatusApp.sol
+++ b/contracts/apps/status/IStatusApp.sol
@@ -5,7 +5,7 @@ contract IStatusOracle {
 }
 
 contract IStatusApp is IStatusOracle {
-    event EntityStatusChanged(address entity, uint8 status);
+    event EntityStatusChanged(address indexed entity, uint8 indexed status);
 
     function setEntityStatus(address entity, uint8 status) external;
 }

--- a/contracts/factories/BasicFactory.sol
+++ b/contracts/factories/BasicFactory.sol
@@ -52,15 +52,17 @@ contract BasicFactory {
     }
 
     function installOrgans(MetaOrgan dao) internal {
-        bytes4[] memory metaorganSigs = new bytes4[](8);
+        bytes4[] memory metaorganSigs = new bytes4[](10);
         metaorganSigs[0] = o0_s0; // setPermissionsOracle(address)
         metaorganSigs[1] = o0_s1; // removeOrgan(bytes4[])
         metaorganSigs[2] = o0_s2; // installOrgan(address,bytes4[])
         metaorganSigs[3] = o0_s3; // installApp(address,bytes4[])
         metaorganSigs[4] = o0_s4; // ceaseToExist()
         metaorganSigs[5] = o0_s5; // get(bytes4)
-        metaorganSigs[6] = o0_s6; // removeApp(bytes4[])
-        metaorganSigs[7] = o0_s7; // replaceKernel(address)
+        metaorganSigs[6] = o0_s6; // updateOrgan(address,bytes4[])
+        metaorganSigs[7] = o0_s7; // removeApp(bytes4[])
+        metaorganSigs[8] = o0_s8; // replaceKernel(address)
+        metaorganSigs[9] = o0_s9; // updateApp(address,bytes4[])
         dao.installOrgan(metaorgan, metaorganSigs);
 
         bytes4[] memory vaultorganSigs = new bytes4[](15);
@@ -91,21 +93,20 @@ contract BasicFactory {
         // Proxies are not working on testrpc, that's why for testing no proxy is created
         Application deployedbylawsapp = Application(_testrpc ? bylawsapp : forwarderFactory.createForwarder(bylawsapp));
         deployedbylawsapp.setDAO(address(dao));
-        bytes4[] memory bylawsappSigs = new bytes4[](14);
+        bytes4[] memory bylawsappSigs = new bytes4[](13);
         bylawsappSigs[0] = a0_s0; // getStatusBylaw(uint256)
         bylawsappSigs[1] = a0_s1; // setCombinatorBylaw(uint256,uint256,uint256,bool)
         bylawsappSigs[2] = a0_s2; // linkBylaw(bytes4,uint256)
         bylawsappSigs[3] = a0_s3; // setStatusBylaw(uint8,bool,bool)
         bylawsappSigs[4] = a0_s4; // setVotingBylaw(uint256,uint256,uint64,uint64,bool)
         bylawsappSigs[5] = a0_s5; // getAddressBylaw(uint256)
-        bylawsappSigs[6] = a0_s6; // negateIfNeeded(bool,bool)
-        bylawsappSigs[7] = a0_s7; // getBylawType(uint256)
-        bylawsappSigs[8] = a0_s8; // getVotingBylaw(uint256)
-        bylawsappSigs[9] = a0_s9; // setAddressBylaw(address,bool,bool)
-        bylawsappSigs[10] = a0_s10; // canPerformAction(address,address,uint256,bytes)
-        bylawsappSigs[11] = a0_s11; // getBylawNot(uint256)
-        bylawsappSigs[12] = a0_s12; // getCombinatorBylaw(uint256)
-        bylawsappSigs[13] = a0_s13; // bylawEntrypoint(bytes4)
+        bylawsappSigs[6] = a0_s6; // getBylawType(uint256)
+        bylawsappSigs[7] = a0_s7; // getVotingBylaw(uint256)
+        bylawsappSigs[8] = a0_s8; // setAddressBylaw(address,bool,bool)
+        bylawsappSigs[9] = a0_s9; // canPerformAction(address,address,uint256,bytes)
+        bylawsappSigs[10] = a0_s10; // getBylawNot(uint256)
+        bylawsappSigs[11] = a0_s11; // getCombinatorBylaw(uint256)
+        bylawsappSigs[12] = a0_s12; // bylawEntrypoint(bytes4)
         dao.installApp(deployedbylawsapp, bylawsappSigs);
 
         // Proxies are not working on testrpc, that's why for testing no proxy is created
@@ -141,13 +142,13 @@ contract BasicFactory {
         deployedstatusapp.setDAO(address(dao));
         bytes4[] memory statusappSigs = new bytes4[](2);
         statusappSigs[0] = a2_s0; // setEntityStatus(address,uint8)
-        statusappSigs[1] = a2_s1; // entityStatus(address)
+        statusappSigs[1] = a2_s1; // getEntityStatus(address)
         dao.installApp(deployedstatusapp, statusappSigs);
 
         // Proxies are not working on testrpc, that's why for testing no proxy is created
         Application deployedvotingapp = Application(_testrpc ? votingapp : forwarderFactory.createForwarder(votingapp));
         deployedvotingapp.setDAO(address(dao));
-        bytes4[] memory votingappSigs = new bytes4[](12);
+        bytes4[] memory votingappSigs = new bytes4[](11);
         votingappSigs[0] = a3_s0; // voteNay(uint256)
         votingappSigs[1] = a3_s1; // getVoteStatus(uint256)
         votingappSigs[2] = a3_s2; // isVoteCodeValid(address)
@@ -158,8 +159,7 @@ contract BasicFactory {
         votingappSigs[7] = a3_s7; // setValidVoteCode(bytes32,bool)
         votingappSigs[8] = a3_s8; // voteYay(uint256)
         votingappSigs[9] = a3_s9; // isVoteApproved(address,uint256,uint256,uint64,uint64)
-        votingappSigs[10] = a3_s10; // getStatusForVoteAddress(address)
-        votingappSigs[11] = a3_s11; // voteYayAndClose(uint256)
+        votingappSigs[10] = a3_s10; // voteYayAndExecute(uint256)
         dao.installApp(deployedvotingapp, votingappSigs);
 
         return deployedbylawsapp; // first app is bylaws
@@ -176,8 +176,10 @@ contract BasicFactory {
         dao_bylaws.linkBylaw(o0_s2, bylaw_2); // installOrgan(address,bytes4[])
         dao_bylaws.linkBylaw(o0_s3, bylaw_3); // installApp(address,bytes4[])
         dao_bylaws.linkBylaw(o0_s4, bylaw_1); // ceaseToExist()
-        dao_bylaws.linkBylaw(o0_s6, bylaw_2); // removeApp(bytes4[])
-        dao_bylaws.linkBylaw(o0_s7, bylaw_2); // replaceKernel(address)
+        dao_bylaws.linkBylaw(o0_s6, bylaw_2); // updateOrgan(address,bytes4[])
+        dao_bylaws.linkBylaw(o0_s7, bylaw_2); // removeApp(bytes4[])
+        dao_bylaws.linkBylaw(o0_s8, bylaw_2); // replaceKernel(address)
+        dao_bylaws.linkBylaw(o0_s9, bylaw_2); // updateApp(address,bytes4[])
         dao_bylaws.linkBylaw(o1_s5, bylaw_4); // deposit(address,uint256)
     }
 
@@ -197,8 +199,10 @@ contract BasicFactory {
     bytes4 constant o0_s3 = 0x59a565d7; // installApp(address,bytes4[])
     bytes4 constant o0_s4 = 0x5bb95c74; // ceaseToExist()
     bytes4 constant o0_s5 = 0x62a2cf0c; // get(bytes4)
-    bytes4 constant o0_s6 = 0x869effe3; // removeApp(bytes4[])
-    bytes4 constant o0_s7 = 0xcebe30ac; // replaceKernel(address)
+    bytes4 constant o0_s6 = 0x78a54225; // updateOrgan(address,bytes4[])
+    bytes4 constant o0_s7 = 0x869effe3; // removeApp(bytes4[])
+    bytes4 constant o0_s8 = 0xcebe30ac; // replaceKernel(address)
+    bytes4 constant o0_s9 = 0xe6f79926; // updateApp(address,bytes4[])
     // vaultorgan
     bytes4 constant o1_s0 = 0x05b1137b; // transferEther(address,uint256)
     bytes4 constant o1_s1 = 0x1ff0769a; // setTokenBlacklist(address,bool)
@@ -224,14 +228,13 @@ contract BasicFactory {
     bytes4 constant a0_s3 = 0x39d2245b; // setStatusBylaw(uint8,bool,bool)
     bytes4 constant a0_s4 = 0x423c962c; // setVotingBylaw(uint256,uint256,uint64,uint64,bool)
     bytes4 constant a0_s5 = 0x50839d11; // getAddressBylaw(uint256)
-    bytes4 constant a0_s6 = 0x51102b4b; // negateIfNeeded(bool,bool)
-    bytes4 constant a0_s7 = 0x7ac41ef5; // getBylawType(uint256)
-    bytes4 constant a0_s8 = 0x7b0dfa35; // getVotingBylaw(uint256)
-    bytes4 constant a0_s9 = 0x81a08245; // setAddressBylaw(address,bool,bool)
-    bytes4 constant a0_s10 = 0xb18fe4f3; // canPerformAction(address,address,uint256,bytes)
-    bytes4 constant a0_s11 = 0xe289793e; // getBylawNot(uint256)
-    bytes4 constant a0_s12 = 0xe69308d2; // getCombinatorBylaw(uint256)
-    bytes4 constant a0_s13 = 0xea986c0a; // bylawEntrypoint(bytes4)
+    bytes4 constant a0_s6 = 0x7ac41ef5; // getBylawType(uint256)
+    bytes4 constant a0_s7 = 0x7b0dfa35; // getVotingBylaw(uint256)
+    bytes4 constant a0_s8 = 0x81a08245; // setAddressBylaw(address,bool,bool)
+    bytes4 constant a0_s9 = 0xb18fe4f3; // canPerformAction(address,address,uint256,bytes)
+    bytes4 constant a0_s10 = 0xe289793e; // getBylawNot(uint256)
+    bytes4 constant a0_s11 = 0xe69308d2; // getCombinatorBylaw(uint256)
+    bytes4 constant a0_s12 = 0xea986c0a; // bylawEntrypoint(bytes4)
     // ownershipapp
     bytes4 constant a1_s0 = 0x10451468; // sale_closeSale()
     bytes4 constant a1_s1 = 0x1fbc147b; // getTokenSale(uint256)
@@ -257,7 +260,7 @@ contract BasicFactory {
     bytes4 constant a1_s21 = 0xf881a92f; // grantTokens(address,address,uint256)
     // statusapp
     bytes4 constant a2_s0 = 0x6035fa06; // setEntityStatus(address,uint8)
-    bytes4 constant a2_s1 = 0x6b87cdc4; // entityStatus(address)
+    bytes4 constant a2_s1 = 0x7c35ae77; // getEntityStatus(address)
     // votingapp
     bytes4 constant a3_s0 = 0x014396f2; // voteNay(uint256)
     bytes4 constant a3_s1 = 0x0519bb83; // getVoteStatus(uint256)
@@ -269,6 +272,5 @@ contract BasicFactory {
     bytes4 constant a3_s7 = 0x64bfa2f6; // setValidVoteCode(bytes32,bool)
     bytes4 constant a3_s8 = 0x8f328d7a; // voteYay(uint256)
     bytes4 constant a3_s9 = 0xad49224c; // isVoteApproved(address,uint256,uint256,uint64,uint64)
-    bytes4 constant a3_s10 = 0xad5dd1f5; // getStatusForVoteAddress(address)
-    bytes4 constant a3_s11 = 0xcf9883e2; // voteYayAndClose(uint256)
+    bytes4 constant a3_s10 = 0xdb82d1e7; // voteYayAndExecute(uint256)
 }

--- a/contracts/factories/ForwarderFactory.sol
+++ b/contracts/factories/ForwarderFactory.sol
@@ -20,5 +20,5 @@ contract ForwarderFactory {
         ForwarderDeployed(fwdContract, target);
     }
 
-    event ForwarderDeployed(address forwarderAddress, address targetContract);
+    event ForwarderDeployed(address forwarderAddress, address indexed targetContract);
 }

--- a/contracts/organs/IVaultOrgan.sol
+++ b/contracts/organs/IVaultOrgan.sol
@@ -2,9 +2,9 @@ pragma solidity ^0.4.11;
 
 contract IVaultOrganEvents {
     event Deposit(address indexed token, address indexed sender, uint256 amount);
-    event Withdraw(address indexed token, address indexed approvedBy, uint256 amount, address recipient);
-    event Recover(address indexed token, address indexed approvedBy, uint256 amount, address recipient);
-    event NewTokenDeposit(address token);
+    event Withdraw(address indexed token, address indexed approvedBy, uint256 amount, address indexed recipient);
+    event Recover(address indexed token, address indexed approvedBy, uint256 amount, address indexed recipient);
+    event NewTokenDeposit(address indexed token);
 }
 
 contract IVaultOrgan is IVaultOrganEvents {

--- a/contracts/organs/MetaOrgan.sol
+++ b/contracts/organs/MetaOrgan.sol
@@ -61,7 +61,7 @@ contract MetaOrgan is IMetaOrgan, IOrgan, KernelRegistry {
     * @notice Updates application atomically
     * #bylaw voting:75,0
     * @param appAddress new address of the receiving contract for functions
-    * @param sigs should be ordered from 0x0 to 0xffffffff
+    * @param sigs should be ordered from 0x0 to 0xffffffff
     */
     function updateApp(address appAddress, bytes4[] sigs) external {
         deregister(sigs, false);
@@ -69,7 +69,7 @@ contract MetaOrgan is IMetaOrgan, IOrgan, KernelRegistry {
     }
 
     /**
-    * @notice Install organ at address `address`
+    * @notice Install organ at address `organAddress`
     * #bylaw voting:75,0
     * @param organAddress address of the receiving contract for functions
     * @param sigs should be ordered from 0x0 to 0xffffffff

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6578,6 +6578,447 @@
         }
       }
     },
+    "solidity-inspector": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/solidity-inspector/-/solidity-inspector-0.1.0.tgz",
+      "integrity": "sha512-Q1lU4Tx/sGXa5sqHZ02OxvcSAgX7+j1pa04o/yjxMO6/NwqF9FOfm4wwNVP4yQ9vY8j0OFmVqUXfPu0OjezZyw==",
+      "dev": true,
+      "requires": {
+        "solidity-parser": "0.4.0",
+        "yargs": "6.6.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "builtin-modules": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+          "dev": true
+        },
+        "camelcase": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+          "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wrap-ansi": "2.1.0"
+          }
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "dev": true
+        },
+        "decamelize": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+          "dev": true
+        },
+        "error-ex": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+          "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+          "dev": true,
+          "requires": {
+            "is-arrayish": "0.2.1"
+          }
+        },
+        "find-up": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+          "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+          "dev": true,
+          "requires": {
+            "path-exists": "2.1.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "get-caller-file": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+          "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+          "dev": true
+        },
+        "hosted-git-info": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+          "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+          "dev": true
+        },
+        "invert-kv": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+          "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+          "dev": true
+        },
+        "is-arrayish": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+          "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+          "dev": true
+        },
+        "is-builtin-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+          "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+          "dev": true,
+          "requires": {
+            "builtin-modules": "1.1.1"
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-utf8": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+          "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+          "dev": true
+        },
+        "lcid": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+          "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+          "dev": true,
+          "requires": {
+            "invert-kv": "1.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "2.2.0",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1",
+            "strip-bom": "2.0.0"
+          }
+        },
+        "lodash.assign": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+          "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+          "dev": true
+        },
+        "normalize-package-data": {
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+          "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "2.5.0",
+            "is-builtin-module": "1.0.0",
+            "semver": "5.4.1",
+            "validate-npm-package-license": "3.0.1"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "dev": true
+        },
+        "os-locale": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+          "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+          "dev": true,
+          "requires": {
+            "lcid": "1.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        },
+        "path-exists": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+          "dev": true,
+          "requires": {
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "path-type": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "pify": "2.3.0",
+            "pinkie-promise": "2.0.1"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+          "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+          "dev": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+          "dev": true,
+          "requires": {
+            "pinkie": "2.0.4"
+          }
+        },
+        "read-pkg": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+          "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "1.1.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "1.1.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+          "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+          "dev": true,
+          "requires": {
+            "find-up": "1.1.2",
+            "read-pkg": "1.1.0"
+          }
+        },
+        "require-directory": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+          "dev": true
+        },
+        "require-main-filename": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.4.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+          "dev": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "dev": true
+        },
+        "solidity-parser": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/solidity-parser/-/solidity-parser-0.4.0.tgz",
+          "integrity": "sha1-o0PxPac8kWgyeQNGgOgMSR3jQPo=",
+          "dev": true,
+          "requires": {
+            "mocha": "2.5.3",
+            "pegjs": "0.10.0",
+            "yargs": "4.8.1"
+          },
+          "dependencies": {
+            "yargs": {
+              "version": "4.8.1",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-4.8.1.tgz",
+              "integrity": "sha1-wMQpJMpKqmsObaFznfshZDn53cA=",
+              "dev": true,
+              "requires": {
+                "cliui": "3.2.0",
+                "decamelize": "1.2.0",
+                "get-caller-file": "1.0.2",
+                "lodash.assign": "4.2.0",
+                "os-locale": "1.4.0",
+                "read-pkg-up": "1.0.1",
+                "require-directory": "2.1.1",
+                "require-main-filename": "1.0.1",
+                "set-blocking": "2.0.0",
+                "string-width": "1.0.2",
+                "which-module": "1.0.0",
+                "window-size": "0.2.0",
+                "y18n": "3.2.1",
+                "yargs-parser": "2.4.1"
+              }
+            }
+          }
+        },
+        "spdx-correct": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+          "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+          "dev": true,
+          "requires": {
+            "spdx-license-ids": "1.2.2"
+          }
+        },
+        "spdx-expression-parse": {
+          "version": "1.0.4",
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+          "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+          "dev": true
+        },
+        "spdx-license-ids": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+          "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-bom": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+          "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+          "dev": true,
+          "requires": {
+            "is-utf8": "0.2.1"
+          }
+        },
+        "validate-npm-package-license": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+          "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+          "dev": true,
+          "requires": {
+            "spdx-correct": "1.0.2",
+            "spdx-expression-parse": "1.0.4"
+          }
+        },
+        "which-module": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+          "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+          "dev": true
+        },
+        "window-size": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.2.0.tgz",
+          "integrity": "sha1-tDFbtCFKPXBY6+7okuE/ok2YsHU=",
+          "dev": true
+        },
+        "wrap-ansi": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+          "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+          "dev": true,
+          "requires": {
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "6.6.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+          "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "cliui": "3.2.0",
+            "decamelize": "1.2.0",
+            "get-caller-file": "1.0.2",
+            "os-locale": "1.4.0",
+            "read-pkg-up": "1.0.1",
+            "require-directory": "2.1.1",
+            "require-main-filename": "1.0.1",
+            "set-blocking": "2.0.0",
+            "string-width": "1.0.2",
+            "which-module": "1.0.0",
+            "y18n": "3.2.1",
+            "yargs-parser": "4.2.1"
+          },
+          "dependencies": {
+            "yargs-parser": {
+              "version": "4.2.1",
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+              "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+              "dev": true,
+              "requires": {
+                "camelcase": "3.0.0"
+              }
+            }
+          }
+        },
+        "yargs-parser": {
+          "version": "2.4.1",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-2.4.1.tgz",
+          "integrity": "sha1-hVaN488VD/SfpRgl8DqMiA3cxcQ=",
+          "dev": true,
+          "requires": {
+            "camelcase": "3.0.0",
+            "lodash.assign": "4.2.0"
+          }
+        }
+      }
+    },
     "solidity-parser": {
       "version": "git+https://github.com/sc-forks/solidity-parser.git#6c544bd308fb6d38b2ca7e2adde9a42334221ab0",
       "dev": true,

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "prepublish": "truffle compile",
+    "generate:factory": "truffle exec scripts/generate_factory.js",
     "test": "truffle test",
     "lint": "solium --dir ./contracts",
     "coverage": "scripts/coverage.sh",
@@ -35,7 +36,8 @@
     "ethereumjs-testrpc": "^4.0.1",
     "handlebars": "^4.0.10",
     "mocha-lcov-reporter": "^1.3.0",
-    "truffle": "^3.4.6",
-    "solidity-coverage": "^0.2.1"
+    "solidity-coverage": "^0.2.1",
+    "solidity-inspector": "^0.1.0",
+    "truffle": "^3.4.6"
   }
 }

--- a/scripts/function_analysis.js
+++ b/scripts/function_analysis.js
@@ -1,0 +1,57 @@
+const fs = require('fs')
+const path = require('path')
+const { signatures } = require('../test/helpers/web3')
+const inspector = require('solidity-inspector')
+
+const getContract = x => artifacts.require(x)
+const flatten = x => [].concat.apply([], x)
+
+const resultFile = path.join(process.cwd(), '../functions.csv')
+
+const organNames = ['organs/MetaOrgan.sol', 'organs/VaultOrgan.sol', 'organs/ActionsOrgan.sol']
+const appNames = ['apps/bylaws/BylawsApp.sol', 'apps/ownership/OwnershipApp.sol', 'apps/status/StatusApp.sol', 'apps/basic-governance/VotingApp.sol']
+const excludeOrgans = ['IOrgan'].map(getContract)
+const excludeApps = ['Application'].map(getContract)
+
+const analizeContract = (f) => {
+    const filePath = path.join(process.cwd(), 'contracts', f)
+    const functions = inspector.parseFile(filePath).toJSON().functions
+
+    return Object.keys(functions)
+        .map(k => functions[k])
+        .filter(f => f.accessModifier != 'internal' && f.accessModifier != 'private')
+}
+
+const contractName = p => path.basename(p).split('.')[0]
+
+module.exports = (done) => {
+    const organData = organNames.map(n => {
+        const d = analizeContract(n)
+        return { name: contractName(n), functions: d.map(f => f.name) }
+    })
+
+    const appData = appNames.map(n => {
+        const d = analizeContract(n)
+        return { name: contractName(n), functions: d.filter(f => f.modifiers.indexOf('onlyDAO') > -1).map(f => f.name) }
+    })
+
+    let content = 'Component,Function,Permissions,Notes\n'
+    for (const organ of organData) {
+        content += `${organ.name},,,\n`
+        for (const f of organ.functions) {
+            content += `,"${f}",,\n`
+        }
+    }
+
+    for (const app of appData) {
+        content += `${app.name},,,\n`
+        for (const f of app.functions) {
+            content += `,"${f}",,\n`
+        }
+    }
+
+    fs.writeFile(resultFile, content, err => {
+        if (err) console.log(err)
+        done()
+    })
+}

--- a/scripts/generate_factory.js
+++ b/scripts/generate_factory.js
@@ -2,7 +2,7 @@ const Handlebars = require('handlebars')
 const fs = require('fs')
 const path = require('path')
 const { signatures } = require('../test/helpers/web3')
-const inspector = require('../../../../../solidity-inspector')
+const inspector = require('solidity-inspector')
 
 const factoryTemplate = path.join(process.cwd(), '../contracts/factories/BasicFactory.sol.tmpl')
 const resultFile = path.join(process.cwd(), '../contracts/factories/BasicFactory.sol')

--- a/test/helpers/web3.js
+++ b/test/helpers/web3.js
@@ -1,7 +1,7 @@
 // TODO: pls abstract promisification over web3
 
 module.exports = {
-  signatures(contract, exclude, web3, names = false) {
+  signatures(contract, exclude, web3, names = false, excludeConstant = false) {
     const flatten = x => [].concat.apply([], x)
     const sig = f => `${f.name}(${f.inputs.map(x=>x.type).join(',')})`
 
@@ -9,6 +9,7 @@ module.exports = {
 
     let signatures = contract.abi
       .filter(x => x.type == 'function')
+      .filter(s => !excludeConstant || !s.constant)
       .map(sig)
       .filter(s => excludedSigs.indexOf(s) < 0)
 

--- a/test/integration_bylaws.js
+++ b/test/integration_bylaws.js
@@ -49,6 +49,16 @@ contract('Bylaws', accounts => {
       assert.equal(await dao.getKernel(), randomAddress, 'Kernel should have been changed')
   })
 
+  it('throws when reseting bylaw', async () => {
+      await bylawsApp.setAddressBylaw(accounts[1], false, false)
+      try {
+         await bylawsApp.setAddressBylaw(accounts[1], false, false)
+      } catch (error) {
+        return assertThrow(error)
+      }
+      assert.fail('should have thrown before')
+  })
+
   context('adding address bylaw', () => {
     beforeEach(async () => {
       bylawId = await bylawsApp.setAddressBylaw.call(accounts[1], false, false)

--- a/test/integration_bylaws.js
+++ b/test/integration_bylaws.js
@@ -91,8 +91,9 @@ contract('Bylaws', accounts => {
     let oracle = {}
     beforeEach(async () => {
       oracle = await BylawOracleMock.new()
-      await bylawsApp.setAddressBylaw(oracle.address, true, false)
       bylawId = await bylawsApp.setAddressBylaw.call(oracle.address, true, false)
+      await bylawsApp.setAddressBylaw(oracle.address, true, false)
+
       await bylawsApp.linkBylaw(changeKernelSig, bylawId)
     })
 
@@ -122,8 +123,9 @@ contract('Bylaws', accounts => {
 
   context('adding negated address bylaw', () => {
     beforeEach(async () => {
-      await bylawsApp.setAddressBylaw(accounts[1], false, true)
       bylawId = await bylawsApp.setAddressBylaw.call(accounts[1], false, true)
+      await bylawsApp.setAddressBylaw(accounts[1], false, true)
+
       await bylawsApp.linkBylaw(changeKernelSig, bylawId)
     })
 
@@ -184,8 +186,9 @@ contract('Bylaws', accounts => {
     })
 
     it('normal vote flow', async () => {
-      await bylawsApp.setVotingBylaw(pct16(50), pct16(40), 5, 5, false)
       bylawId = await bylawsApp.setVotingBylaw.call(pct16(50), pct16(40), 5, 5, false)
+      await bylawsApp.setVotingBylaw(pct16(50), pct16(40), 5, 5, false)
+
       await bylawsApp.linkBylaw(changeKernelSig, bylawId)
       await votingApp.createVote(vote.address, startBlock, finalBlock)
       await votingApp.mock_setBlockNumber(startBlock)
@@ -206,8 +209,9 @@ contract('Bylaws', accounts => {
     })
 
     it('vote prematurely decided flow with vote yay and execute', async () => {
-      await bylawsApp.setVotingBylaw(pct16(50), pct16(40), 5, 5, false)
       bylawId = await bylawsApp.setVotingBylaw.call(pct16(50), pct16(40), 5, 5, false)
+      await bylawsApp.setVotingBylaw(pct16(50), pct16(40), 5, 5, false)
+
       await bylawsApp.linkBylaw(changeKernelSig, bylawId)
       await votingApp.createVote(vote.address, startBlock, finalBlock)
       await votingApp.mock_setBlockNumber(startBlock)
@@ -219,8 +223,9 @@ contract('Bylaws', accounts => {
     })
 
     it('throws if voting hasnt been successful', async () => {
-      await bylawsApp.setVotingBylaw(pct16(50), pct16(40), 5, 5, false)
       bylawId = await bylawsApp.setVotingBylaw.call(pct16(50), pct16(40), 5, 5, false)
+      await bylawsApp.setVotingBylaw(pct16(50), pct16(40), 5, 5, false)
+
       await bylawsApp.linkBylaw(changeKernelSig, bylawId)
       await votingApp.createVote(vote.address, startBlock, finalBlock)
       await votingApp.mock_setBlockNumber(startBlock)
@@ -238,8 +243,9 @@ contract('Bylaws', accounts => {
     })
 
     it('throws if voting had no votes', async () => {
-      await bylawsApp.setVotingBylaw(pct16(50), pct16(40), 5, 5, false)
       bylawId = await bylawsApp.setVotingBylaw.call(pct16(50), pct16(40), 5, 5, false)
+      await bylawsApp.setVotingBylaw(pct16(50), pct16(40), 5, 5, false)
+
       await bylawsApp.linkBylaw(changeKernelSig, bylawId)
       await votingApp.createVote(vote.address, startBlock, finalBlock)
       await votingApp.mock_setBlockNumber(finalBlock)
@@ -253,8 +259,9 @@ contract('Bylaws', accounts => {
     })
 
     it('throws if voting didnt get enough quorum', async () => {
-      await bylawsApp.setVotingBylaw(pct16(50), pct16(21), 5, 5, false)
       bylawId = await bylawsApp.setVotingBylaw.call(pct16(50), pct16(21), 5, 5, false)
+      await bylawsApp.setVotingBylaw(pct16(50), pct16(21), 5, 5, false)
+
       await bylawsApp.linkBylaw(changeKernelSig, bylawId)
       await votingApp.createVote(vote.address, startBlock, finalBlock)
       await votingApp.mock_setBlockNumber(startBlock)
@@ -271,8 +278,9 @@ contract('Bylaws', accounts => {
     })
 
     it('throws when attempting to execute action twice', async () => {
-      await bylawsApp.setVotingBylaw(pct16(50), pct16(40), 5, 5, false)
       bylawId = await bylawsApp.setVotingBylaw.call(pct16(50), pct16(40), 5, 5, false)
+      await bylawsApp.setVotingBylaw(pct16(50), pct16(40), 5, 5, false)
+
       await bylawsApp.linkBylaw(changeKernelSig, bylawId)
       await votingApp.createVote(vote.address, startBlock, finalBlock)
       await votingApp.mock_setBlockNumber(startBlock)
@@ -310,8 +318,9 @@ contract('Bylaws', accounts => {
       await ownershipApp.grantTokens(token.address, holder1, 10)
       await ownershipApp.grantTokens(token2.address, holder2, 1)
 
-      await bylawsApp.setStatusBylaw(0, true, false)
       bylawId = await bylawsApp.setStatusBylaw.call(0, true, false)
+      await bylawsApp.setStatusBylaw(0, true, false)
+
       await bylawsApp.linkBylaw(changeKernelSig, bylawId)
     })
 
@@ -355,8 +364,9 @@ contract('Bylaws', accounts => {
 
       await statusApp.setEntityStatus(authorized, authLevel)
       await statusApp.setEntityStatus(lowauth, authLevel - 1)
-      await bylawsApp.setStatusBylaw(authLevel, false, false)
       bylawId = await bylawsApp.setStatusBylaw.call(authLevel, false, false)
+      await bylawsApp.setStatusBylaw(authLevel, false, false)
+
       await bylawsApp.linkBylaw(changeKernelSig, bylawId)
     })
 
@@ -390,17 +400,18 @@ contract('Bylaws', accounts => {
     beforeEach(async () => {
       oracle = await BylawOracleMock.new()
 
-      await bylawsApp.setAddressBylaw(allowedAddress, false, false)
-      await bylawsApp.setAddressBylaw(oracle.address, true, false)
-
       addressBylaw = await bylawsApp.setAddressBylaw.call(allowedAddress, false, false)
       oracleBylaw = await bylawsApp.setAddressBylaw.call(oracle.address, true, false)
+
+      await bylawsApp.setAddressBylaw(allowedAddress, false, false)
+      await bylawsApp.setAddressBylaw(oracle.address, true, false)
     })
 
     context('adding OR bylaw', () => {
       beforeEach(async () => {
-        await bylawsApp.setCombinatorBylaw(0, addressBylaw, oracleBylaw, false)
         bylawId = await bylawsApp.setCombinatorBylaw.call(0, addressBylaw, oracleBylaw, false)
+        await bylawsApp.setCombinatorBylaw(0, addressBylaw, oracleBylaw, false)
+
         await bylawsApp.linkBylaw(changeKernelSig, bylawId)
       })
 
@@ -440,8 +451,8 @@ contract('Bylaws', accounts => {
 
     context('adding AND bylaw', () => {
       beforeEach(async () => {
-        await bylawsApp.setCombinatorBylaw(1, addressBylaw, oracleBylaw, false)
         bylawId = await bylawsApp.setCombinatorBylaw.call(1, addressBylaw, oracleBylaw, false)
+        await bylawsApp.setCombinatorBylaw(1, addressBylaw, oracleBylaw, false)
         await bylawsApp.linkBylaw(changeKernelSig, bylawId)
       })
 
@@ -480,8 +491,9 @@ contract('Bylaws', accounts => {
 
     context('adding XOR bylaw', () => {
       beforeEach(async () => {
-        await bylawsApp.setCombinatorBylaw(2, addressBylaw, oracleBylaw, false)
         bylawId = await bylawsApp.setCombinatorBylaw.call(2, addressBylaw, oracleBylaw, false)
+        await bylawsApp.setCombinatorBylaw(2, addressBylaw, oracleBylaw, false)
+
         await bylawsApp.linkBylaw(changeKernelSig, bylawId)
       })
 

--- a/test/integration_bylaws.js
+++ b/test/integration_bylaws.js
@@ -398,8 +398,8 @@ contract('Bylaws', accounts => {
         assert.equal(await bylawsApp.getBylawType(bylawId), 5, 'bylaw type should be correct')
         const [t, l, r] = await bylawsApp.getCombinatorBylaw(bylawId)
         assert.equal(t, 0, 'comb type should be correct')
-        assert.equal(l, addressBylaw, 'comb type should be correct')
-        assert.equal(r, oracleBylaw, 'comb type should be correct')
+        assert.equal(l.toString(), addressBylaw.toString(), 'addr bylaw should be correct')
+        assert.equal(r.toString(), oracleBylaw.toString(), 'oracle bylaw should be correct')
       })
 
       it('allows action if address is correct', async () => {
@@ -431,15 +431,16 @@ contract('Bylaws', accounts => {
     context('adding AND bylaw', () => {
       beforeEach(async () => {
         await bylawsApp.setCombinatorBylaw(1, addressBylaw, oracleBylaw, false)
-        await bylawsApp.linkBylaw(changeKernelSig, 3)
+        bylawId = await bylawsApp.setCombinatorBylaw.call(1, addressBylaw, oracleBylaw, false)
+        await bylawsApp.linkBylaw(changeKernelSig, bylawId)
       })
 
       it('saved bylaw correctly', async () => {
-        assert.equal(await bylawsApp.getBylawType(3), 5, 'bylaw type should be correct')
-        const [t, l, r] = await bylawsApp.getCombinatorBylaw(3)
+        assert.equal(await bylawsApp.getBylawType(bylawId), 5, 'bylaw type should be correct')
+        const [t, l, r] = await bylawsApp.getCombinatorBylaw(bylawId)
         assert.equal(t, 1, 'comb type should be correct')
-        assert.equal(l, addressBylaw, 'comb type should be correct')
-        assert.equal(r, oracleBylaw, 'comb type should be correct')
+        assert.equal(l.toString(), addressBylaw.toString(), 'addr bylaw should be correct')
+        assert.equal(r.toString(), oracleBylaw.toString(), 'oracle bylaw should be correct')
       })
 
       it('allows action if both are true', async () => {
@@ -470,15 +471,17 @@ contract('Bylaws', accounts => {
     context('adding XOR bylaw', () => {
       beforeEach(async () => {
         await bylawsApp.setCombinatorBylaw(2, addressBylaw, oracleBylaw, false)
-        await bylawsApp.linkBylaw(changeKernelSig, 3)
+        bylawId = await bylawsApp.setCombinatorBylaw.call(2, addressBylaw, oracleBylaw, false)
+        await bylawsApp.linkBylaw(changeKernelSig, bylawId)
       })
 
       it('saved bylaw correctly', async () => {
-        assert.equal(await bylawsApp.getBylawType(3), 5, 'bylaw type should be correct')
-        const [t, l, r] = await bylawsApp.getCombinatorBylaw(3)
+        assert.equal(await bylawsApp.getBylawType(bylawId), 5, 'bylaw type should be correct')
+        const [t, l, r] = await bylawsApp.getCombinatorBylaw(bylawId)
         assert.equal(t, 2, 'comb type should be correct')
-        assert.equal(l, addressBylaw, 'comb type should be correct')
-        assert.equal(r, oracleBylaw, 'comb type should be correct')      })
+        assert.equal(l.toString(), addressBylaw.toString(), 'addr bylaw should be correct')
+        assert.equal(r.toString(), oracleBylaw.toString(), 'oracle bylaw should be correct')
+      })
 
       it('allows when only first allows', async () => {
         await oracle.changeAllow(false)


### PR DESCRIPTION
This PR focuses on improving security of multiple things:
- Bylaw ids being incremental integers were vulnerable to chain reorg attacks (submit a bylaw and expect it to have id x and it end up being y). Now the bylaw id is a hash of the parameters of the bylaw so it is deterministic. 
- Makes sure the DAO reference of an app cannot be changed once it has been set. 