### PR TITLE
Add appId and version to applications as metadata

### DIFF
--- a/contracts/apps/IApplication.sol
+++ b/contracts/apps/IApplication.sol
@@ -4,4 +4,6 @@ import "../misc/DAOMsg.sol";
 
 contract IApplication is DAOMsgReader {
     function init() internal;
+    function appId() constant returns (string);
+    function version() constant returns (string);
 }

--- a/contracts/apps/basic-governance/VotingApp.sol
+++ b/contracts/apps/basic-governance/VotingApp.sol
@@ -17,17 +17,6 @@ import "./IVote.sol";
 import "./IVotingApp.sol";
 
 contract VotingApp is IVotingApp, Application, CodeHelper {
-    function VotingApp(address daoAddr)
-    Application(daoAddr)
-    {
-        // init is automatically called by setDAO
-    }
-
-    function init() internal {
-        assert(votes.length == 0); // asserts init can only be called once
-        votes.length++; // index 0 is empty
-    }
-
     // hash(bytecode) -> bool. Is the hash of some bytecode approved voting code?
     mapping (bytes32 => bool) public validVoteCode;
 
@@ -59,6 +48,25 @@ contract VotingApp is IVotingApp, Application, CodeHelper {
 
     Vote[] votes;  // array for storage of all votes
     mapping (address => uint) voteForAddress; // reverse index to quickly get the voteId for a vote address
+
+    function VotingApp(address daoAddr)
+    Application(daoAddr)
+    {
+        // init is automatically called by setDAO
+    }
+
+    function init() internal {
+        assert(votes.length == 0); // asserts init can only be called once
+        votes.length++; // index 0 is empty
+    }
+
+    function appId() constant returns (string) {
+        return "voting.aragonpm.eth";
+    }
+
+    function version() constant returns (string) {
+        return "1.0.0";
+    }
 
     /**
     * @notice Create a new vote for `IVote(_voteAddress).data()`

--- a/contracts/apps/bylaws/BylawsApp.sol
+++ b/contracts/apps/bylaws/BylawsApp.sol
@@ -76,6 +76,14 @@ contract BylawsApp is IBylawsApp, Application {
         bylaw.not = true;
     }
 
+    function appId() constant returns (string) {
+        return "bylaws.aragonpm.eth";
+    }
+
+    function version() constant returns (string) {
+        return "1.0.0";
+    }
+
     /**
     * @notice Set bylaw `_id` responsible for checking action `_sig`
     * @dev Links a signature entrypoint to a bylaw.

--- a/contracts/apps/ownership/OwnershipApp.sol
+++ b/contracts/apps/ownership/OwnershipApp.sol
@@ -50,6 +50,14 @@ contract OwnershipApp is Application, IOwnershipApp, Requestor {
         tokens.length += 1;
     }
 
+    function appId() constant returns (string) {
+        return "ownership.aragonpm.eth";
+    }
+
+    function version() constant returns (string) {
+        return "1.0.0";
+    }
+
     /**
     * @notice Add token at `_tokenAddress` as a governance token to the organization
     * @dev If added token is not controlled by DAO, it will fail to issue tokens

--- a/contracts/apps/status/StatusApp.sol
+++ b/contracts/apps/status/StatusApp.sol
@@ -13,6 +13,15 @@ contract StatusApp is IStatusApp, Application {
 
     function StatusApp(address _dao)
                      Application(_dao) {}
+
+    function appId() constant returns (string) {
+        return "status.aragonpm.eth";
+    }
+
+    function version() constant returns (string) {
+        return "1.0.0";
+    }
+
     /**
     * @dev Assign status `_status` to `_entity`
     * @param _entity Address of the entity being modified

--- a/test/dao_msg.js
+++ b/test/dao_msg.js
@@ -73,7 +73,7 @@ contract('DAO msg', accounts => {
       let tester = {}
       beforeEach(async () => {
           await installApps(metadao, [DAOMsgApp])
-          tester = DAOMsgOrgan.at(dao.address)
+          tester = DAOMsgApp.at(dao.address)
       })
 
       context('', tests)

--- a/test/helpers/DAOMsgOrgan.sol
+++ b/test/helpers/DAOMsgOrgan.sol
@@ -14,7 +14,15 @@ contract DAOMsgOrgan is IOrgan {
 
 contract DAOMsgApp is Application {
     function DAOMsgApp() Application(0) {}
-        
+
+    function appId() constant returns (string) {
+        return "mock.aragonpm.eth";
+    }
+
+    function version() constant returns (string) {
+        return "1.0.0";
+    }
+
     function assertDaoMsg(address sender, address token, uint256 value) payable {
         require(dao_msg().sender == sender);
         require(dao_msg().token == token);

--- a/test/mocks/MockedApp.sol
+++ b/test/mocks/MockedApp.sol
@@ -15,8 +15,11 @@ contract MockedApp is Application {
     didStuff = true;
   }
 
-  function canHandlePayload(bytes p) constant returns (bool) {
-    p; // silence warning
-    return true; // can handle all the payloads
+  function appId() constant returns (string) {
+      return "mock.aragonpm.eth";
+  }
+
+  function version() constant returns (string) {
+      return "1.0.0";
   }
 }


### PR DESCRIPTION
Alternative implementation to close #88. 

Instead of changing the `register` function logic when the client sees a new app being added it can just do `app.appId()` or `app.version()`.

@onbjerg opinions?