### PR TITLE
Standardize events' tense

### DIFF
--- a/contracts/apps/basic-governance/IVotingApp.sol
+++ b/contracts/apps/basic-governance/IVotingApp.sol
@@ -5,9 +5,9 @@ contract IVotingOracle {
 }
 
 contract IVotingApp is IVotingOracle {
-    event VoteCreated(uint indexed voteId, address voteAddress);
-    event VoteCasted(uint indexed voteId, address voter, bool isYay, uint votes);
-    event VoteStateChanged(uint indexed voteId, uint oldState, uint newState);
+    event NewVote(uint indexed voteId, address voteAddress);
+    event CastVote(uint indexed voteId, address voter, bool isYay, uint votes);
+    event ChangeVoteState(uint indexed voteId, uint oldState, uint newState);
 
     function createVote(address _voteAddress, uint64 _voteStartsBlock, uint64 _voteEndsBlock) external;
     function voteYay(uint _voteId) public;

--- a/contracts/apps/basic-governance/VotingApp.sol
+++ b/contracts/apps/basic-governance/VotingApp.sol
@@ -82,7 +82,7 @@ contract VotingApp is IVotingApp, Application, CodeHelper {
         vote.voteEndsBlock = _voteEndsBlock;
         voteForAddress[_voteAddress] = voteId;
 
-        VoteCreated(voteId, _voteAddress);
+        NewVote(voteId, _voteAddress);
         transitionStateIfChanged(voteId); // vote can start in this block
     }
 
@@ -137,19 +137,19 @@ contract VotingApp is IVotingApp, Application, CodeHelper {
         // Multiple state transitions can happen at once
         if (vote.state == VoteState.Debate && getBlockNumber() >= vote.voteStartsBlock) {
             transitionToVotingState(vote);
-            VoteStateChanged(_voteId, uint(VoteState.Debate), uint(VoteState.Voting));
+            ChangeVoteState(_voteId, uint(VoteState.Debate), uint(VoteState.Voting));
         }
 
         bool voteWasExecuted = IVote(votes[_voteId].voteAddress).wasExecuted();
 
         if (vote.state == VoteState.Voting && (voteWasExecuted || getBlockNumber() > vote.voteEndsBlock || vote.governanceTokens.length == 0 || vote.totalQuorum == 0)) {
             vote.state = VoteState.Closed;
-            VoteStateChanged(_voteId, uint(VoteState.Voting), uint(VoteState.Closed));
+            ChangeVoteState(_voteId, uint(VoteState.Voting), uint(VoteState.Closed));
         }
 
         if (vote.state == VoteState.Closed && voteWasExecuted) {
             vote.state = VoteState.Executed;
-            VoteStateChanged(_voteId, uint(VoteState.Closed), uint(VoteState.Executed));
+            ChangeVoteState(_voteId, uint(VoteState.Closed), uint(VoteState.Executed));
         }
     }
 
@@ -263,7 +263,7 @@ contract VotingApp is IVotingApp, Application, CodeHelper {
 
         vote.voted[_voter] = _isYay ? 1 : 2;
 
-        VoteCasted(
+        CastVote(
             _voteId,
             _voter,
             _isYay,

--- a/contracts/apps/bylaws/BylawsApp.sol
+++ b/contracts/apps/bylaws/BylawsApp.sol
@@ -91,7 +91,7 @@ contract BylawsApp is IBylawsApp, Application {
     {
         bylawEntrypoint[_sig] = _id;
 
-        BylawChanged(
+        ChangeBylaw(
             _sig,
             getBylawType(_id),
             _id,

--- a/contracts/apps/bylaws/IBylawsApp.sol
+++ b/contracts/apps/bylaws/IBylawsApp.sol
@@ -4,7 +4,7 @@ import "../../kernel/IPermissionsOracle.sol";
 
 contract IBylawsApp {
     event NewBylaw(uint bylawId);
-    event BylawChanged(bytes4 sig, uint bylawType, uint256 bylawId, address changedBy);
+    event ChangeBylaw(bytes4 sig, uint bylawType, uint256 bylawId, address changedBy);
 
     function linkBylaw(bytes4 _sig, uint _id) external;
 

--- a/contracts/apps/ownership/IOwnershipApp.sol
+++ b/contracts/apps/ownership/IOwnershipApp.sol
@@ -13,11 +13,11 @@ contract IOwnershipSale {
 }
 
 contract IOwnershipApp is ITokenHolderOracle, IOwnershipSale, MiniMeController {
-    event AddedToken(address indexed tokenAddress, uint indexed tokenId);
-    event RemovedToken(address indexed tokenAddress);
-    event ChangedTokenId(address indexed tokenAddress, uint indexed oldTokenId, uint indexed newTokenId);
-    event NewTokenSale(address indexed saleAddress, uint indexed saleId);
-    event TokenSaleClosed(address indexed saleAddress, uint indexed saleId);
+    event AddToken(address indexed tokenAddress, uint indexed tokenId);
+    event RemoveToken(address indexed tokenAddress);
+    event ChangeTokenId(address indexed tokenAddress, uint indexed oldTokenId, uint indexed newTokenId);
+    event CreateTokenSale(address indexed saleAddress, uint indexed saleId);
+    event CloseTokenSale(address indexed saleAddress, uint indexed saleId);
 
     function addToken(address tokenAddress, uint256 issueAmount, uint128 governanceRights, uint128 economicRights) external;
     function removeToken(address tokenAddress) external;

--- a/contracts/apps/ownership/OwnershipApp.sol
+++ b/contracts/apps/ownership/OwnershipApp.sol
@@ -79,7 +79,7 @@ contract OwnershipApp is Application, IOwnershipApp, Requestor {
         tokenIdForAddress[_tokenAddress] = tokenId;
 
         updateIsController(_tokenAddress);
-        AddedToken(_tokenAddress, tokenId);
+        AddToken(_tokenAddress, tokenId);
 
         if (_tokenAddress > 0)
             issueTokens(_tokenAddress, _issueAmount);
@@ -96,12 +96,12 @@ contract OwnershipApp is Application, IOwnershipApp, Requestor {
             tokens[tokenId] = tokens[tokens.length - 1];
             tokenIdForAddress[tokens[tokenId].tokenAddress] = tokenId;
 
-            ChangedTokenId(tokens[tokenId].tokenAddress, tokens.length - 1, tokenId);
+            ChangeTokenId(tokens[tokenId].tokenAddress, tokens.length - 1, tokenId);
         }
         tokenIdForAddress[tokens[tokens.length - 1].tokenAddress] = 0;
         tokens.length--;
 
-        RemovedToken(_tokenAddress);
+        RemoveToken(_tokenAddress);
     }
 
     /**
@@ -187,7 +187,7 @@ contract OwnershipApp is Application, IOwnershipApp, Requestor {
         uint saleId = salesLength - 1; // last item is newly added sale
         tokenSaleForAddress[_saleAddress] = saleId;
 
-        NewTokenSale(_saleAddress, saleId);
+        CreateTokenSale(_saleAddress, saleId);
     }
 
     /**
@@ -294,7 +294,7 @@ contract OwnershipApp is Application, IOwnershipApp, Requestor {
         require(!tokenSales[saleId].closed);
         tokenSales[saleId].closed = true;
 
-        TokenSaleClosed(tokenSales[saleId].saleAddress, saleId);
+        CloseTokenSale(tokenSales[saleId].saleAddress, saleId);
     }
 
     modifier only_controlled(address _tokenAddress) {

--- a/contracts/apps/status/IStatusApp.sol
+++ b/contracts/apps/status/IStatusApp.sol
@@ -5,7 +5,7 @@ contract IStatusOracle {
 }
 
 contract IStatusApp is IStatusOracle {
-    event EntityStatusChanged(address indexed entity, uint8 indexed status);
+    event ChangeEntityStatus(address indexed entity, uint8 indexed status);
 
     function setEntityStatus(address entity, uint8 status) external;
 }

--- a/contracts/apps/status/StatusApp.sol
+++ b/contracts/apps/status/StatusApp.sol
@@ -20,7 +20,7 @@ contract StatusApp is IStatusApp, Application {
     */
     function setEntityStatus(address _entity, uint8 _status) onlyDAO external {
         entityStatus[_entity] = _status;
-        EntityStatusChanged(_entity, _status);
+        ChangeEntityStatus(_entity, _status);
     }
 
     function getEntityStatus(address entity) constant public returns (uint) {

--- a/contracts/factories/BasicFactory.sol
+++ b/contracts/factories/BasicFactory.sol
@@ -13,7 +13,7 @@ import "../apps/bylaws/BylawsApp.sol";
 import "./ForwarderFactory.sol";
 
 contract BasicFactory {
-    event DeployedDAO(address dao);
+    event DeployDAO(address dao);
     address public kernel;
     ForwarderFactory public forwarderFactory;
     address public metaorgan;
@@ -48,7 +48,7 @@ contract BasicFactory {
         MetaOrgan(dao).setPermissionsOracle(bylawsApp);
         // TODO: set status for sender
 
-        DeployedDAO(dao);
+        DeployDAO(dao);
     }
 
     function installOrgans(MetaOrgan dao) internal {
@@ -71,9 +71,9 @@ contract BasicFactory {
         vaultorganSigs[2] = o1_s2; // setupEtherToken()
         vaultorganSigs[3] = o1_s3; // getTokenBalance(address)
         vaultorganSigs[4] = o1_s4; // getScapeHatch()
-        vaultorganSigs[5] = o1_s5; // deposit(address,uint256)
-        vaultorganSigs[6] = o1_s6; // recover(address,address)
-        vaultorganSigs[7] = o1_s7; // setEtherToken(address)
+        vaultorganSigs[5] = o1_s5; // recover(address,address)
+        vaultorganSigs[6] = o1_s6; // setEtherToken(address)
+        vaultorganSigs[7] = o1_s7; // deposit(address,address,uint256)
         vaultorganSigs[8] = o1_s8; // scapeHatch(address[])
         vaultorganSigs[9] = o1_s9; // getEtherToken()
         vaultorganSigs[10] = o1_s10; // getHaltTime()
@@ -93,7 +93,7 @@ contract BasicFactory {
         // Proxies are not working on testrpc, that's why for testing no proxy is created
         Application deployedbylawsapp = Application(_testrpc ? bylawsapp : forwarderFactory.createForwarder(bylawsapp));
         deployedbylawsapp.setDAO(address(dao));
-        bytes4[] memory bylawsappSigs = new bytes4[](13);
+        bytes4[] memory bylawsappSigs = new bytes4[](15);
         bylawsappSigs[0] = a0_s0; // getStatusBylaw(uint256)
         bylawsappSigs[1] = a0_s1; // setCombinatorBylaw(uint256,uint256,uint256,bool)
         bylawsappSigs[2] = a0_s2; // linkBylaw(bytes4,uint256)
@@ -104,9 +104,11 @@ contract BasicFactory {
         bylawsappSigs[7] = a0_s7; // getVotingBylaw(uint256)
         bylawsappSigs[8] = a0_s8; // setAddressBylaw(address,bool,bool)
         bylawsappSigs[9] = a0_s9; // canPerformAction(address,address,uint256,bytes)
-        bylawsappSigs[10] = a0_s10; // getBylawNot(uint256)
-        bylawsappSigs[11] = a0_s11; // getCombinatorBylaw(uint256)
-        bylawsappSigs[12] = a0_s12; // bylawEntrypoint(bytes4)
+        bylawsappSigs[10] = a0_s10; // isTokenWhitelisted(address)
+        bylawsappSigs[11] = a0_s11; // setTokenWhitelist(address,bool)
+        bylawsappSigs[12] = a0_s12; // getBylawNot(uint256)
+        bylawsappSigs[13] = a0_s13; // getCombinatorBylaw(uint256)
+        bylawsappSigs[14] = a0_s14; // bylawEntrypoint(bytes4)
         dao.installApp(deployedbylawsapp, bylawsappSigs);
 
         // Proxies are not working on testrpc, that's why for testing no proxy is created
@@ -180,7 +182,7 @@ contract BasicFactory {
         dao_bylaws.linkBylaw(o0_s7, bylaw_2); // removeApp(bytes4[])
         dao_bylaws.linkBylaw(o0_s8, bylaw_2); // replaceKernel(address)
         dao_bylaws.linkBylaw(o0_s9, bylaw_2); // updateApp(address,bytes4[])
-        dao_bylaws.linkBylaw(o1_s5, bylaw_4); // deposit(address,uint256)
+        dao_bylaws.linkBylaw(o1_s7, bylaw_4); // deposit(address,address,uint256)
     }
 
     function pct(uint x) internal constant returns (uint) {
@@ -209,9 +211,9 @@ contract BasicFactory {
     bytes4 constant o1_s2 = 0x21a342e8; // setupEtherToken()
     bytes4 constant o1_s3 = 0x3aecd0e3; // getTokenBalance(address)
     bytes4 constant o1_s4 = 0x4371677c; // getScapeHatch()
-    bytes4 constant o1_s5 = 0x47e7ef24; // deposit(address,uint256)
-    bytes4 constant o1_s6 = 0x648bf774; // recover(address,address)
-    bytes4 constant o1_s7 = 0x6ad419a8; // setEtherToken(address)
+    bytes4 constant o1_s5 = 0x648bf774; // recover(address,address)
+    bytes4 constant o1_s6 = 0x6ad419a8; // setEtherToken(address)
+    bytes4 constant o1_s7 = 0x8340f549; // deposit(address,address,uint256)
     bytes4 constant o1_s8 = 0x863ca8f0; // scapeHatch(address[])
     bytes4 constant o1_s9 = 0x877d08ee; // getEtherToken()
     bytes4 constant o1_s10 = 0xae2ae305; // getHaltTime()
@@ -232,9 +234,11 @@ contract BasicFactory {
     bytes4 constant a0_s7 = 0x7b0dfa35; // getVotingBylaw(uint256)
     bytes4 constant a0_s8 = 0x81a08245; // setAddressBylaw(address,bool,bool)
     bytes4 constant a0_s9 = 0xb18fe4f3; // canPerformAction(address,address,uint256,bytes)
-    bytes4 constant a0_s10 = 0xe289793e; // getBylawNot(uint256)
-    bytes4 constant a0_s11 = 0xe69308d2; // getCombinatorBylaw(uint256)
-    bytes4 constant a0_s12 = 0xea986c0a; // bylawEntrypoint(bytes4)
+    bytes4 constant a0_s10 = 0xb5af090f; // isTokenWhitelisted(address)
+    bytes4 constant a0_s11 = 0xc9bcc97e; // setTokenWhitelist(address,bool)
+    bytes4 constant a0_s12 = 0xe289793e; // getBylawNot(uint256)
+    bytes4 constant a0_s13 = 0xe69308d2; // getCombinatorBylaw(uint256)
+    bytes4 constant a0_s14 = 0xea986c0a; // bylawEntrypoint(bytes4)
     // ownershipapp
     bytes4 constant a1_s0 = 0x10451468; // sale_closeSale()
     bytes4 constant a1_s1 = 0x1fbc147b; // getTokenSale(uint256)

--- a/contracts/factories/BasicFactory.sol.tmpl
+++ b/contracts/factories/BasicFactory.sol.tmpl
@@ -13,7 +13,7 @@ import "../apps/bylaws/BylawsApp.sol";
 import "./ForwarderFactory.sol";
 
 contract BasicFactory {
-    event DeployedDAO(address dao);
+    event DeployDAO(address dao);
     address public kernel;
     ForwarderFactory public forwarderFactory;
     {{#organs}}
@@ -46,7 +46,7 @@ contract BasicFactory {
         MetaOrgan(dao).setPermissionsOracle(bylawsApp);
         // TODO: set status for sender
 
-        DeployedDAO(dao);
+        DeployDAO(dao);
     }
 
     function installOrgans(MetaOrgan dao) internal {

--- a/contracts/factories/ForwarderFactory.sol
+++ b/contracts/factories/ForwarderFactory.sol
@@ -17,8 +17,8 @@ contract ForwarderFactory {
             switch extcodesize(fwdContract) case 0 { invalid() }
         }
 
-        ForwarderDeployed(fwdContract, target);
+        DeployForwarder(fwdContract, target);
     }
 
-    event ForwarderDeployed(address forwarderAddress, address indexed targetContract);
+    event DeployForwarder(address forwarderAddress, address indexed targetContract);
 }

--- a/contracts/organs/IMetaOrgan.sol
+++ b/contracts/organs/IMetaOrgan.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.4.11;
 
 contract IMetaOrganEvents {
-    event KernelReplaced(address newKernel);
-    event PermissionsOracleReplaced(address newPermissionsOracle);
+    event ReplaceKernel(address newKernel);
+    event ReplacePermissionsOracle(address newPermissionsOracle);
 }
 
 contract IMetaOrgan is IMetaOrganEvents {

--- a/contracts/organs/MetaOrgan.sol
+++ b/contracts/organs/MetaOrgan.sol
@@ -26,7 +26,7 @@ contract MetaOrgan is IMetaOrgan, IOrgan, KernelRegistry {
     */
     function replaceKernel(address newKernel) external {
         setKernel(newKernel);
-        KernelReplaced(newKernel);
+        ReplaceKernel(newKernel);
     }
 
     /**
@@ -35,7 +35,7 @@ contract MetaOrgan is IMetaOrgan, IOrgan, KernelRegistry {
     */
     function setPermissionsOracle(address newOracle) external {
         storageSet(PERMISSION_ORACLE_KEY, uint256(newOracle));
-        PermissionsOracleReplaced(newOracle);
+        ReplacePermissionsOracle(newOracle);
     }
 
     /**


### PR DESCRIPTION
Closes #89.
Made all events to the present tense, so it fits zeppelin's tense (`Transfer` etc).