### PR TITLE
Implement Entity based VotingApp

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -2,4 +2,5 @@ module.exports = {
     norpc: true,
     testCommand: 'node --max-old-space-size=4096 ../node_modules/.bin/truffle test --network coverage',
     skipFiles: ['network/AragonResolver.sol', 'misc/Migrations.sol'],
+    copyNodeModules: true,
 }

--- a/contracts/apps/App.sol
+++ b/contracts/apps/App.sol
@@ -4,7 +4,7 @@ import "./AppStorage.sol";
 
 contract App is AppStorage {
     modifier auth {
-        require(kernel.canPerform(msg.sender, address(this), msg.sig));
+        require(address(kernel) == 0 || kernel.canPerform(msg.sender, address(this), msg.sig));
         _;
     }
 }

--- a/contracts/apps/voting/EVMScriptRunner.sol
+++ b/contracts/apps/voting/EVMScriptRunner.sol
@@ -19,7 +19,7 @@ contract EVMScriptRunner {
         }
     }
 
-    function makeSingleScript(address to, bytes calldata) internal returns (bytes script) {
+    function makeSingleScript(address to, bytes calldata) constant returns (bytes script) {
         uint l = 20 + 32 + calldata.length;
 
         uint srcPointer; uint dstPointer;

--- a/contracts/apps/voting/EVMScriptRunner.sol
+++ b/contracts/apps/voting/EVMScriptRunner.sol
@@ -1,0 +1,92 @@
+pragma solidity 0.4.15;
+
+// Inspired by https://github.com/reverendus/tx-manager
+
+contract EVMScriptRunner {
+    function runScript(bytes script) internal {
+        uint256 location = 0;
+        while (location < script.length) {
+            address contractAddress = addressAt(script, location);
+            uint256 calldataLength = uint256At(script, location + 0x14);
+            uint256 calldataStart = locationOf(script, location + 0x14 + 0x20);
+            uint8 ok;
+            assembly {
+                ok := call(sub(gas, 5000), contractAddress, 0, calldataStart, calldataLength, 0, 0)
+            }
+            if (ok == 0) revert();
+
+            location += (0x14 + 0x20 + calldataLength);
+        }
+    }
+
+    function makeSingleScript(address to, bytes calldata) returns (bytes script) {
+        uint l = 20 + 32 + calldata.length;
+
+        uint srcPointer; uint dstPointer;
+        assembly {
+            script := mload(0x40)
+            mstore(0x40, add(script, add(l, 0x20)))
+            mstore(add(script, 0x14), to)
+            mstore(script, l)
+            srcPointer := calldata
+            dstPointer := add(script, add(0x20, 0x14))
+        }
+
+        memcpy(dstPointer, srcPointer, 32 + calldata.length);
+    }
+
+    function getScriptAction(bytes script, uint256 i) constant returns (address, bytes) {
+        uint256 location = 0;
+        while (location < script.length) {
+            uint256 calldataLength = uint256At(script, location + 0x14);
+            if (i == 0) {
+                bytes memory calldata;
+                uint256 calldataPtr = locationOf(script, location + 0x14);
+                assembly { calldata := calldataPtr }
+                return (addressAt(script, location), calldata);
+            }
+
+            location += (0x14 + 0x20 + calldataLength);
+            i--;
+        }
+    }
+
+    function uint256At(bytes data, uint256 location) internal returns (uint256 result) {
+        assembly {
+            result := mload(add(data, add(0x20, location)))
+        }
+    }
+
+    function addressAt(bytes data, uint256 location) internal returns (address result) {
+        uint256 word = uint256At(data, location);
+        assembly {
+            result := div(and(word, 0xffffffffffffffffffffffffffffffffffffffff000000000000000000000000),
+                          0x1000000000000000000000000)
+        }
+    }
+
+    function locationOf(bytes data, uint256 location) internal returns (uint256 result) {
+        assembly {
+            result := add(data, add(0x20, location))
+        }
+    }
+
+    function memcpy(uint dest, uint src, uint len) private {
+        // Copy word-length chunks while possible
+        for(; len >= 32; len -= 32) {
+            assembly {
+                mstore(dest, mload(src))
+            }
+            dest += 32;
+            src += 32;
+        }
+
+        // Copy remaining bytes
+        uint mask = 256 ** (32 - len) - 1;
+        assembly {
+            let srcpart := and(mload(src), not(mask))
+            let destpart := and(mload(dest), mask)
+            mstore(dest, or(destpart, srcpart))
+        }
+    }
+}

--- a/contracts/apps/voting/EVMScriptRunner.sol
+++ b/contracts/apps/voting/EVMScriptRunner.sol
@@ -66,6 +66,7 @@ contract EVMScriptRunner {
 
     function addressAt(bytes data, uint256 location) private returns (address result) {
         uint256 word = uint256At(data, location);
+
         assembly {
             result := div(and(word, 0xffffffffffffffffffffffffffffffffffffffff000000000000000000000000),
                           0x1000000000000000000000000)

--- a/contracts/apps/voting/VotingApp.sol
+++ b/contracts/apps/voting/VotingApp.sol
@@ -118,6 +118,10 @@ contract VotingApp is App, Initializable, EVMScriptRunner {
         scriptActionsCount = getScriptActionsCount(voting.executionScript);
     }
 
+    function getVotingScriptAction(uint256 _votingId, uint256 _scriptAction) constant returns (address, bytes) {
+        return getScriptAction(votings[_votingId].executionScript, _scriptAction);
+    }
+
     function _vote(uint256 _votingId, bool _supports, address _voter) internal {
         Voting storage voting = votings[_votingId];
 

--- a/contracts/apps/voting/VotingApp.sol
+++ b/contracts/apps/voting/VotingApp.sol
@@ -1,0 +1,122 @@
+pragma solidity 0.4.15;
+
+import "../App.sol";
+
+import "../../common/Initializable.sol";
+import "../../common/MiniMeToken.sol";
+
+import "zeppelin-solidity/contracts/math/SafeMath.sol";
+
+contract VotingApp is App, Initializable {
+    using SafeMath for uint256;
+
+    MiniMeToken public token;
+    uint256 public supportRequiredPct;
+    uint256 public minAcceptQuorumPct;
+    uint64 public voteTime;
+
+    uint256 constant PCT_BASE = 10 ** 18;
+
+    enum VoterState { Absent, Yea, Nay }
+
+    struct Voting {
+        address creator;
+        uint64 startDate;
+        uint256 snapshotBlock;
+        uint256 yea;
+        uint256 nay;
+        uint256 totalSupply;
+        bytes executionScript;
+        bool open;
+        bool executed;
+
+        mapping (address => VoterState) voters;
+    }
+
+    Voting[] votings;
+    mapping (bytes32 => uint256) idByHash;
+
+    event StartVote(uint256 indexed votingId, bytes32 votingHash);
+    event CastVote(uint256 indexed votingId, bytes32 indexed votingHash, address indexed voter, bool supports);
+
+    function initialize(MiniMeToken _token, uint256 _supportRequiredPct, uint256 _minAcceptQuorumPct, uint64 _voteTime) onlyInit {
+        initialized();
+
+        require(_supportRequiredPct <= PCT_BASE);
+        require(_supportRequiredPct >= _minAcceptQuorumPct);
+
+        token = _token;
+        supportRequiredPct = _supportRequiredPct;
+        minAcceptQuorumPct = _minAcceptQuorumPct;
+        voteTime = _voteTime;
+
+        votings.length += 1;
+    }
+
+    function newVoting(bytes _executionScript) auth {
+        uint256 votingId = votings.length++;
+        Voting storage voting = votings[votingId];
+        voting.executionScript = _executionScript;
+        voting.creator = msg.sender;
+        voting.startDate = uint64(now);
+        voting.open = true;
+        voting.snapshotBlock = getBlockNumber() - 1; // avoid double voting in this very block
+        voting.totalSupply = token.totalSupplyAt(voting.snapshotBlock);
+
+        bytes32 h = votingHash(votingId);
+        idByHash[h] = votingId;
+
+        StartVote(votingId, h);
+    }
+
+    function vote(bytes32 _votingHash, bool _supports) {
+        uint256 votingId = idByHash[_votingHash];
+        require(votingId > 0);
+
+        Voting storage voting = votings[votingId];
+        require(voting.open);
+        require(uint64(now) < voting.startDate + voteTime);
+
+        address voter = msg.sender;
+
+        // this could re-enter, though we can asume the governance token is not maliciuous
+        uint256 voterStake = token.balanceOfAt(voter, voting.snapshotBlock);
+        VoterState state = voting.voters[voter];
+
+        // if voter had previously voted, decrease count
+        if (state == VoterState.Yea) voting.yea = voting.yea.sub(voterStake);
+        if (state == VoterState.Nay) voting.nay = voting.nay.sub(voterStake);
+
+        if (_supports) voting.yea = voting.yea.add(voterStake);
+        else           voting.nay = voting.nay.add(voterStake);
+
+        voting.voters[voter] = _supports ? VoterState.Yea : VoterState.Nay;
+
+        CastVote(votingId, _votingHash, voter, _supports);
+    }
+
+    function canExecute(uint256 _votingId) constant returns (bool) {
+        Voting storage voting = votings[_votingId];
+
+        // Voting is already decided
+        if (voting.yea >= pct(voting.totalSupply, supportRequiredPct))
+            return true;
+
+        uint256 totalVotes = voting.yea + voting.nay;
+        if (uint64(now) >= voting.startDate + voteTime &&
+            voting.yea >= pct(totalVotes, supportRequiredPct) &&
+            voting.yea >= pct(voting.totalSupply, minAcceptQuorumPct))
+            return true;
+
+        return false;
+    }
+
+    function pct(uint256 x, uint p) internal returns (uint256) {
+        return x * p / PCT_BASE;
+    }
+
+    function votingHash(uint256 _votingId) constant returns (bytes32) {
+        Voting storage voting = votings[_votingId];
+        return sha3(_votingId, voting.creator, voting.executionScript);
+    }
+}

--- a/contracts/apps/voting/VotingApp.sol
+++ b/contracts/apps/voting/VotingApp.sol
@@ -30,7 +30,6 @@ contract VotingApp is App, Initializable, EVMScriptRunner {
         bytes executionScript;
         bool open;
         bool executed;
-
         mapping (address => VoterState) voters;
     }
 

--- a/contracts/apps/voting/VotingApp.sol
+++ b/contracts/apps/voting/VotingApp.sol
@@ -112,7 +112,7 @@ contract VotingApp is App, Initializable, EVMScriptRunner {
         Voting storage voting = votings[_votingId];
 
         return voting.open &&
-               uint64(now) < voting.startDate + voteTime &&
+               uint64(now) < (voting.startDate + voteTime) &&
                token.balanceOfAt(_voter, voting.snapshotBlock) > 0;
     }
 
@@ -124,7 +124,7 @@ contract VotingApp is App, Initializable, EVMScriptRunner {
             return true;
 
         uint256 totalVotes = voting.yea + voting.nay;
-        if (uint64(now) >= voting.startDate + voteTime &&
+        if (uint64(now) >= (voting.startDate + voteTime) &&
             voting.yea >= pct(totalVotes, supportRequiredPct) &&
             voting.yea >= pct(voting.totalVoters, minAcceptQuorumPct))
             return true;

--- a/contracts/common/MiniMeToken.sol
+++ b/contracts/common/MiniMeToken.sol
@@ -1,0 +1,602 @@
+pragma solidity ^0.4.6;
+
+/*
+    Copyright 2016, Jordi Baylina
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/// @title MiniMeToken Contract
+/// @author Jordi Baylina
+/// @dev This token contract's goal is to make it easy for anyone to clone this
+///  token using the token distribution at a given block, this will allow DAO's
+///  and DApps to upgrade their features in a decentralized manner without
+///  affecting the original token
+/// @dev It is ERC20 compliant, but still needs to under go further testing.
+
+
+/// @dev The token controller contract must implement these functions
+contract TokenController {
+    /// @notice Called when `_owner` sends ether to the MiniMe Token contract
+    /// @param _owner The address that sent the ether to create tokens
+    /// @return True if the ether is accepted, false if it throws
+    function proxyPayment(address _owner) payable returns(bool);
+
+    /// @notice Notifies the controller about a token transfer allowing the
+    ///  controller to react if desired
+    /// @param _from The origin of the transfer
+    /// @param _to The destination of the transfer
+    /// @param _amount The amount of the transfer
+    /// @return False if the controller does not authorize the transfer
+    function onTransfer(address _from, address _to, uint _amount) returns(bool);
+
+    /// @notice Notifies the controller about an approval allowing the
+    ///  controller to react if desired
+    /// @param _owner The address that calls `approve()`
+    /// @param _spender The spender in the `approve()` call
+    /// @param _amount The amount in the `approve()` call
+    /// @return False if the controller does not authorize the approval
+    function onApprove(address _owner, address _spender, uint _amount)
+        returns(bool);
+}
+
+contract Controlled {
+    /// @notice The address of the controller is the only address that can call
+    ///  a function with this modifier
+    modifier onlyController { require(msg.sender == controller); _; }
+
+    address public controller;
+
+    function Controlled() { controller = msg.sender;}
+
+    /// @notice Changes the controller of the contract
+    /// @param _newController The new controller of the contract
+    function changeController(address _newController) onlyController {
+        controller = _newController;
+    }
+}
+
+contract ApproveAndCallFallBack {
+    function receiveApproval(address from, uint256 _amount, address _token, bytes _data);
+}
+
+/// @dev The actual token contract, the default controller is the msg.sender
+///  that deploys the contract, so usually this token will be deployed by a
+///  token controller contract, which Giveth will call a "Campaign"
+contract MiniMeToken is Controlled {
+
+    string public name;                //The Token's name: e.g. DigixDAO Tokens
+    uint8 public decimals;             //Number of decimals of the smallest unit
+    string public symbol;              //An identifier: e.g. REP
+    string public version = 'MMT_0.1'; //An arbitrary versioning scheme
+
+
+    /// @dev `Checkpoint` is the structure that attaches a block number to a
+    ///  given value, the block number attached is the one that last changed the
+    ///  value
+    struct  Checkpoint {
+
+        // `fromBlock` is the block number that the value was generated from
+        uint128 fromBlock;
+
+        // `value` is the amount of tokens at a specific block number
+        uint128 value;
+    }
+
+    // `parentToken` is the Token address that was cloned to produce this token;
+    //  it will be 0x0 for a token that was not cloned
+    MiniMeToken public parentToken;
+
+    // `parentSnapShotBlock` is the block number from the Parent Token that was
+    //  used to determine the initial distribution of the Clone Token
+    uint public parentSnapShotBlock;
+
+    // `creationBlock` is the block number that the Clone Token was created
+    uint public creationBlock;
+
+    // `balances` is the map that tracks the balance of each address, in this
+    //  contract when the balance changes the block number that the change
+    //  occurred is also included in the map
+    mapping (address => Checkpoint[]) balances;
+
+    // `allowed` tracks any extra transfer rights as in all ERC20 tokens
+    mapping (address => mapping (address => uint256)) allowed;
+
+    // Tracks the history of the `totalSupply` of the token
+    Checkpoint[] totalSupplyHistory;
+
+    // Flag that determines if the token is transferable or not.
+    bool public transfersEnabled;
+
+    // The factory used to create new clone tokens
+    MiniMeTokenFactory public tokenFactory;
+
+////////////////
+// Constructor
+////////////////
+
+    /// @notice Constructor to create a MiniMeToken
+    /// @param _tokenFactory The address of the MiniMeTokenFactory contract that
+    ///  will create the Clone token contracts, the token factory needs to be
+    ///  deployed first
+    /// @param _parentToken Address of the parent token, set to 0x0 if it is a
+    ///  new token
+    /// @param _parentSnapShotBlock Block of the parent token that will
+    ///  determine the initial distribution of the clone token, set to 0 if it
+    ///  is a new token
+    /// @param _tokenName Name of the new token
+    /// @param _decimalUnits Number of decimals of the new token
+    /// @param _tokenSymbol Token Symbol for the new token
+    /// @param _transfersEnabled If true, tokens will be able to be transferred
+    function MiniMeToken(
+        address _tokenFactory,
+        address _parentToken,
+        uint _parentSnapShotBlock,
+        string _tokenName,
+        uint8 _decimalUnits,
+        string _tokenSymbol,
+        bool _transfersEnabled
+    ) {
+        tokenFactory = MiniMeTokenFactory(_tokenFactory);
+        name = _tokenName;                                 // Set the name
+        decimals = _decimalUnits;                          // Set the decimals
+        symbol = _tokenSymbol;                             // Set the symbol
+        parentToken = MiniMeToken(_parentToken);
+        parentSnapShotBlock = _parentSnapShotBlock;
+        transfersEnabled = _transfersEnabled;
+        creationBlock = block.number;
+    }
+
+
+///////////////////
+// ERC20 Methods
+///////////////////
+
+    /// @notice Send `_amount` tokens to `_to` from `msg.sender`
+    /// @param _to The address of the recipient
+    /// @param _amount The amount of tokens to be transferred
+    /// @return Whether the transfer was successful or not
+    function transfer(address _to, uint256 _amount) returns (bool success) {
+        require(transfersEnabled);
+        return doTransfer(msg.sender, _to, _amount);
+    }
+
+    /// @notice Send `_amount` tokens to `_to` from `_from` on the condition it
+    ///  is approved by `_from`
+    /// @param _from The address holding the tokens being transferred
+    /// @param _to The address of the recipient
+    /// @param _amount The amount of tokens to be transferred
+    /// @return True if the transfer was successful
+    function transferFrom(address _from, address _to, uint256 _amount
+    ) returns (bool success) {
+
+        // The controller of this contract can move tokens around at will,
+        //  this is important to recognize! Confirm that you trust the
+        //  controller of this contract, which in most situations should be
+        //  another open source smart contract or 0x0
+        if (msg.sender != controller) {
+            require(transfersEnabled);
+
+            // The standard ERC 20 transferFrom functionality
+            if (allowed[_from][msg.sender] < _amount) return false;
+            allowed[_from][msg.sender] -= _amount;
+        }
+        return doTransfer(_from, _to, _amount);
+    }
+
+    /// @dev This is the actual transfer function in the token contract, it can
+    ///  only be called by other functions in this contract.
+    /// @param _from The address holding the tokens being transferred
+    /// @param _to The address of the recipient
+    /// @param _amount The amount of tokens to be transferred
+    /// @return True if the transfer was successful
+    function doTransfer(address _from, address _to, uint _amount
+    ) internal returns(bool) {
+
+           if (_amount == 0) {
+               return true;
+           }
+
+           require(parentSnapShotBlock < block.number);
+
+           // Do not allow transfer to 0x0 or the token contract itself
+           require((_to != 0) && (_to != address(this)));
+
+           // If the amount being transfered is more than the balance of the
+           //  account the transfer returns false
+           var previousBalanceFrom = balanceOfAt(_from, block.number);
+           if (previousBalanceFrom < _amount) {
+               return false;
+           }
+
+           // Alerts the token controller of the transfer
+           if (isContract(controller)) {
+               require(TokenController(controller).onTransfer(_from, _to, _amount));
+           }
+
+           // First update the balance array with the new value for the address
+           //  sending the tokens
+           updateValueAtNow(balances[_from], previousBalanceFrom - _amount);
+
+           // Then update the balance array with the new value for the address
+           //  receiving the tokens
+           var previousBalanceTo = balanceOfAt(_to, block.number);
+           require(previousBalanceTo + _amount >= previousBalanceTo); // Check for overflow
+           updateValueAtNow(balances[_to], previousBalanceTo + _amount);
+
+           // An event to make the transfer easy to find on the blockchain
+           Transfer(_from, _to, _amount);
+
+           return true;
+    }
+
+    /// @param _owner The address that's balance is being requested
+    /// @return The balance of `_owner` at the current block
+    function balanceOf(address _owner) constant returns (uint256 balance) {
+        return balanceOfAt(_owner, block.number);
+    }
+
+    /// @notice `msg.sender` approves `_spender` to spend `_amount` tokens on
+    ///  its behalf. This is a modified version of the ERC20 approve function
+    ///  to be a little bit safer
+    /// @param _spender The address of the account able to transfer the tokens
+    /// @param _amount The amount of tokens to be approved for transfer
+    /// @return True if the approval was successful
+    function approve(address _spender, uint256 _amount) returns (bool success) {
+        require(transfersEnabled);
+
+        // To change the approve amount you first have to reduce the addresses`
+        //  allowance to zero by calling `approve(_spender,0)` if it is not
+        //  already 0 to mitigate the race condition described here:
+        //  https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+        require((_amount == 0) || (allowed[msg.sender][_spender] == 0));
+
+        // Alerts the token controller of the approve function call
+        if (isContract(controller)) {
+            require(TokenController(controller).onApprove(msg.sender, _spender, _amount));
+        }
+
+        allowed[msg.sender][_spender] = _amount;
+        Approval(msg.sender, _spender, _amount);
+        return true;
+    }
+
+    /// @dev This function makes it easy to read the `allowed[]` map
+    /// @param _owner The address of the account that owns the token
+    /// @param _spender The address of the account able to transfer the tokens
+    /// @return Amount of remaining tokens of _owner that _spender is allowed
+    ///  to spend
+    function allowance(address _owner, address _spender
+    ) constant returns (uint256 remaining) {
+        return allowed[_owner][_spender];
+    }
+
+    /// @notice `msg.sender` approves `_spender` to send `_amount` tokens on
+    ///  its behalf, and then a function is triggered in the contract that is
+    ///  being approved, `_spender`. This allows users to use their tokens to
+    ///  interact with contracts in one function call instead of two
+    /// @param _spender The address of the contract able to transfer the tokens
+    /// @param _amount The amount of tokens to be approved for transfer
+    /// @return True if the function call was successful
+    function approveAndCall(address _spender, uint256 _amount, bytes _extraData
+    ) returns (bool success) {
+        require(approve(_spender, _amount));
+
+        ApproveAndCallFallBack(_spender).receiveApproval(
+            msg.sender,
+            _amount,
+            this,
+            _extraData
+        );
+
+        return true;
+    }
+
+    /// @dev This function makes it easy to get the total number of tokens
+    /// @return The total number of tokens
+    function totalSupply() constant returns (uint) {
+        return totalSupplyAt(block.number);
+    }
+
+
+////////////////
+// Query balance and totalSupply in History
+////////////////
+
+    /// @dev Queries the balance of `_owner` at a specific `_blockNumber`
+    /// @param _owner The address from which the balance will be retrieved
+    /// @param _blockNumber The block number when the balance is queried
+    /// @return The balance at `_blockNumber`
+    function balanceOfAt(address _owner, uint _blockNumber) constant
+        returns (uint) {
+
+        // These next few lines are used when the balance of the token is
+        //  requested before a check point was ever created for this token, it
+        //  requires that the `parentToken.balanceOfAt` be queried at the
+        //  genesis block for that token as this contains initial balance of
+        //  this token
+        if ((balances[_owner].length == 0)
+            || (balances[_owner][0].fromBlock > _blockNumber)) {
+            if (address(parentToken) != 0) {
+                return parentToken.balanceOfAt(_owner, min(_blockNumber, parentSnapShotBlock));
+            } else {
+                // Has no parent
+                return 0;
+            }
+
+        // This will return the expected balance during normal situations
+        } else {
+            return getValueAt(balances[_owner], _blockNumber);
+        }
+    }
+
+    /// @notice Total amount of tokens at a specific `_blockNumber`.
+    /// @param _blockNumber The block number when the totalSupply is queried
+    /// @return The total amount of tokens at `_blockNumber`
+    function totalSupplyAt(uint _blockNumber) constant returns(uint) {
+
+        // These next few lines are used when the totalSupply of the token is
+        //  requested before a check point was ever created for this token, it
+        //  requires that the `parentToken.totalSupplyAt` be queried at the
+        //  genesis block for this token as that contains totalSupply of this
+        //  token at this block number.
+        if ((totalSupplyHistory.length == 0)
+            || (totalSupplyHistory[0].fromBlock > _blockNumber)) {
+            if (address(parentToken) != 0) {
+                return parentToken.totalSupplyAt(min(_blockNumber, parentSnapShotBlock));
+            } else {
+                return 0;
+            }
+
+        // This will return the expected totalSupply during normal situations
+        } else {
+            return getValueAt(totalSupplyHistory, _blockNumber);
+        }
+    }
+
+////////////////
+// Clone Token Method
+////////////////
+
+    /// @notice Creates a new clone token with the initial distribution being
+    ///  this token at `_snapshotBlock`
+    /// @param _cloneTokenName Name of the clone token
+    /// @param _cloneDecimalUnits Number of decimals of the smallest unit
+    /// @param _cloneTokenSymbol Symbol of the clone token
+    /// @param _snapshotBlock Block when the distribution of the parent token is
+    ///  copied to set the initial distribution of the new clone token;
+    ///  if the block is zero than the actual block, the current block is used
+    /// @param _transfersEnabled True if transfers are allowed in the clone
+    /// @return The address of the new MiniMeToken Contract
+    function createCloneToken(
+        string _cloneTokenName,
+        uint8 _cloneDecimalUnits,
+        string _cloneTokenSymbol,
+        uint _snapshotBlock,
+        bool _transfersEnabled
+        ) returns(address) {
+        if (_snapshotBlock == 0) _snapshotBlock = block.number;
+        MiniMeToken cloneToken = tokenFactory.createCloneToken(
+            this,
+            _snapshotBlock,
+            _cloneTokenName,
+            _cloneDecimalUnits,
+            _cloneTokenSymbol,
+            _transfersEnabled
+            );
+
+        cloneToken.changeController(msg.sender);
+
+        // An event to make the token easy to find on the blockchain
+        NewCloneToken(address(cloneToken), _snapshotBlock);
+        return address(cloneToken);
+    }
+
+////////////////
+// Generate and destroy tokens
+////////////////
+
+    /// @notice Generates `_amount` tokens that are assigned to `_owner`
+    /// @param _owner The address that will be assigned the new tokens
+    /// @param _amount The quantity of tokens generated
+    /// @return True if the tokens are generated correctly
+    function generateTokens(address _owner, uint _amount
+    ) onlyController returns (bool) {
+        uint curTotalSupply = totalSupply();
+        require(curTotalSupply + _amount >= curTotalSupply); // Check for overflow
+        uint previousBalanceTo = balanceOf(_owner);
+        require(previousBalanceTo + _amount >= previousBalanceTo); // Check for overflow
+        updateValueAtNow(totalSupplyHistory, curTotalSupply + _amount);
+        updateValueAtNow(balances[_owner], previousBalanceTo + _amount);
+        Transfer(0, _owner, _amount);
+        return true;
+    }
+
+
+    /// @notice Burns `_amount` tokens from `_owner`
+    /// @param _owner The address that will lose the tokens
+    /// @param _amount The quantity of tokens to burn
+    /// @return True if the tokens are burned correctly
+    function destroyTokens(address _owner, uint _amount
+    ) onlyController returns (bool) {
+        uint curTotalSupply = totalSupply();
+        require(curTotalSupply >= _amount);
+        uint previousBalanceFrom = balanceOf(_owner);
+        require(previousBalanceFrom >= _amount);
+        updateValueAtNow(totalSupplyHistory, curTotalSupply - _amount);
+        updateValueAtNow(balances[_owner], previousBalanceFrom - _amount);
+        Transfer(_owner, 0, _amount);
+        return true;
+    }
+
+////////////////
+// Enable tokens transfers
+////////////////
+
+
+    /// @notice Enables token holders to transfer their tokens freely if true
+    /// @param _transfersEnabled True if transfers are allowed in the clone
+    function enableTransfers(bool _transfersEnabled) onlyController {
+        transfersEnabled = _transfersEnabled;
+    }
+
+////////////////
+// Internal helper functions to query and set a value in a snapshot array
+////////////////
+
+    /// @dev `getValueAt` retrieves the number of tokens at a given block number
+    /// @param checkpoints The history of values being queried
+    /// @param _block The block number to retrieve the value at
+    /// @return The number of tokens being queried
+    function getValueAt(Checkpoint[] storage checkpoints, uint _block
+    ) constant internal returns (uint) {
+        if (checkpoints.length == 0) return 0;
+
+        // Shortcut for the actual value
+        if (_block >= checkpoints[checkpoints.length-1].fromBlock)
+            return checkpoints[checkpoints.length-1].value;
+        if (_block < checkpoints[0].fromBlock) return 0;
+
+        // Binary search of the value in the array
+        uint min = 0;
+        uint max = checkpoints.length-1;
+        while (max > min) {
+            uint mid = (max + min + 1)/ 2;
+            if (checkpoints[mid].fromBlock<=_block) {
+                min = mid;
+            } else {
+                max = mid-1;
+            }
+        }
+        return checkpoints[min].value;
+    }
+
+    /// @dev `updateValueAtNow` used to update the `balances` map and the
+    ///  `totalSupplyHistory`
+    /// @param checkpoints The history of data being updated
+    /// @param _value The new number of tokens
+    function updateValueAtNow(Checkpoint[] storage checkpoints, uint _value
+    ) internal  {
+        if ((checkpoints.length == 0)
+        || (checkpoints[checkpoints.length -1].fromBlock < block.number)) {
+               Checkpoint storage newCheckPoint = checkpoints[ checkpoints.length++ ];
+               newCheckPoint.fromBlock =  uint128(block.number);
+               newCheckPoint.value = uint128(_value);
+           } else {
+               Checkpoint storage oldCheckPoint = checkpoints[checkpoints.length-1];
+               oldCheckPoint.value = uint128(_value);
+           }
+    }
+
+    /// @dev Internal function to determine if an address is a contract
+    /// @param _addr The address being queried
+    /// @return True if `_addr` is a contract
+    function isContract(address _addr) constant internal returns(bool) {
+        uint size;
+        if (_addr == 0) return false;
+        assembly {
+            size := extcodesize(_addr)
+        }
+        return size>0;
+    }
+
+    /// @dev Helper function to return a min betwen the two uints
+    function min(uint a, uint b) internal returns (uint) {
+        return a < b ? a : b;
+    }
+
+    /// @notice The fallback function: If the contract's controller has not been
+    ///  set to 0, then the `proxyPayment` method is called which relays the
+    ///  ether and creates tokens as described in the token controller contract
+    function ()  payable {
+        require(isContract(controller));
+        require(TokenController(controller).proxyPayment.value(msg.value)(msg.sender));
+    }
+
+//////////
+// Safety Methods
+//////////
+
+    /// @notice This method can be used by the controller to extract mistakenly
+    ///  sent tokens to this contract.
+    /// @param _token The address of the token contract that you want to recover
+    ///  set to 0 in case you want to extract ether.
+    function claimTokens(address _token) onlyController {
+        if (_token == 0x0) {
+            controller.transfer(this.balance);
+            return;
+        }
+
+        MiniMeToken token = MiniMeToken(_token);
+        uint balance = token.balanceOf(this);
+        token.transfer(controller, balance);
+        ClaimedTokens(_token, controller, balance);
+    }
+
+////////////////
+// Events
+////////////////
+    event ClaimedTokens(address indexed _token, address indexed _controller, uint _amount);
+    event Transfer(address indexed _from, address indexed _to, uint256 _amount);
+    event NewCloneToken(address indexed _cloneToken, uint _snapshotBlock);
+    event Approval(
+        address indexed _owner,
+        address indexed _spender,
+        uint256 _amount
+        );
+
+}
+
+
+////////////////
+// MiniMeTokenFactory
+////////////////
+
+/// @dev This contract is used to generate clone contracts from a contract.
+///  In solidity this is the way to create a contract from a contract of the
+///  same class
+contract MiniMeTokenFactory {
+
+    /// @notice Update the DApp by creating a new token with new functionalities
+    ///  the msg.sender becomes the controller of this clone token
+    /// @param _parentToken Address of the token being cloned
+    /// @param _snapshotBlock Block of the parent token that will
+    ///  determine the initial distribution of the clone token
+    /// @param _tokenName Name of the new token
+    /// @param _decimalUnits Number of decimals of the new token
+    /// @param _tokenSymbol Token Symbol for the new token
+    /// @param _transfersEnabled If true, tokens will be able to be transferred
+    /// @return The address of the new token contract
+    function createCloneToken(
+        address _parentToken,
+        uint _snapshotBlock,
+        string _tokenName,
+        uint8 _decimalUnits,
+        string _tokenSymbol,
+        bool _transfersEnabled
+    ) returns (MiniMeToken) {
+        MiniMeToken newToken = new MiniMeToken(
+            this,
+            _parentToken,
+            _snapshotBlock,
+            _tokenName,
+            _decimalUnits,
+            _tokenSymbol,
+            _transfersEnabled
+            );
+
+        newToken.changeController(msg.sender);
+        return newToken;
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -198,6 +198,45 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
     },
+    "babel-cli": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
+      "integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
+      "dev": true,
+      "requires": {
+        "babel-core": "6.26.0",
+        "babel-polyfill": "6.26.0",
+        "babel-register": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "chokidar": "1.7.0",
+        "commander": "2.11.0",
+        "convert-source-map": "1.5.0",
+        "fs-readdir-recursive": "1.0.0",
+        "glob": "7.1.2",
+        "lodash": "4.17.4",
+        "output-file-sync": "1.1.2",
+        "path-is-absolute": "1.0.1",
+        "slash": "1.0.0",
+        "source-map": "0.5.7",
+        "v8flags": "2.1.1"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
@@ -2269,6 +2308,12 @@
         "rimraf": "2.6.1"
       }
     },
+    "fs-readdir-recursive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.0.0.tgz",
+      "integrity": "sha1-jNF0XItPiinIyuw5JHaSG6GV9WA=",
+      "dev": true
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3871,6 +3916,12 @@
       "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
       "dev": true
     },
+    "left-pad": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.1.3.tgz",
+      "integrity": "sha1-YS9hwDPzqeCOk58crr7qQbbzGZo=",
+      "dev": true
+    },
     "level-codec": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-7.0.1.tgz",
@@ -4615,6 +4666,17 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+    },
+    "output-file-sync": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
+      "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "4.1.11",
+        "mkdirp": "0.5.1",
+        "object-assign": "4.1.1"
+      }
     },
     "p-finally": {
       "version": "1.0.0",
@@ -5495,6 +5557,37 @@
         }
       }
     },
+    "solidity-sha3": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/solidity-sha3/-/solidity-sha3-0.4.1.tgz",
+      "integrity": "sha1-F1d+k/bP1YSJxOx/LaMEdTAynsE=",
+      "dev": true,
+      "requires": {
+        "babel-cli": "6.26.0",
+        "babel-preset-es2015": "6.24.1",
+        "babel-register": "6.26.0",
+        "left-pad": "1.1.3",
+        "web3": "0.16.0"
+      },
+      "dependencies": {
+        "bignumber.js": {
+          "version": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+          "dev": true
+        },
+        "web3": {
+          "version": "0.16.0",
+          "resolved": "https://registry.npmjs.org/web3/-/web3-0.16.0.tgz",
+          "integrity": "sha1-pFVBdc1GKUMDWx8dOUMvdBxrYBk=",
+          "dev": true,
+          "requires": {
+            "bignumber.js": "git+https://github.com/debris/bignumber.js.git#c7a38de919ed75e6fb6ba38051986e294b328df9",
+            "crypto-js": "3.1.8",
+            "utf8": "2.1.2",
+            "xmlhttprequest": "1.8.0"
+          }
+        }
+      }
+    },
     "solium": {
       "version": "0.5.5",
       "resolved": "https://registry.npmjs.org/solium/-/solium-0.5.5.tgz",
@@ -6061,6 +6154,12 @@
         }
       }
     },
+    "user-home": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz",
+      "integrity": "sha1-K1viOjK2Onyd640PKNSFcko98ZA=",
+      "dev": true
+    },
     "utf8": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.2.tgz",
@@ -6092,6 +6191,15 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
       "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho="
+    },
+    "v8flags": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
+      "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
+      "dev": true,
+      "requires": {
+        "user-home": "1.1.1"
+      }
     },
     "validate-npm-package-license": {
       "version": "3.0.1",

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "zeppelin-solidity": "^1.2.0"
   },
   "devDependencies": {
-    "babel-polyfill": "^6.26.0",
     "babel-helpers": "^6.24.1",
+    "babel-polyfill": "^6.26.0",
     "babel-preset-es2015": "^6.18.0",
     "babel-preset-stage-2": "^6.24.1",
     "babel-preset-stage-3": "^6.17.0",
@@ -39,6 +39,7 @@
     "mocha-lcov-reporter": "^1.3.0",
     "solidity-coverage": "^0.2.2",
     "solidity-inspector": "^0.1.2",
+    "solidity-sha3": "^0.4.1",
     "truffle": "^3.4.9"
   }
 }

--- a/test/apps_voting.js
+++ b/test/apps_voting.js
@@ -1,0 +1,150 @@
+const sha3 = require('solidity-sha3').default
+
+const { assertInvalidOpcode } = require('./helpers/assertThrow')
+const { getBlockNumber } = require('./helpers/web3')
+const timetravel = require('./helpers/timer')
+
+const VotingApp = artifacts.require('VotingApp')
+const MiniMeToken = artifacts.require('MiniMeToken')
+
+const ExecutionTarget = artifacts.require('ExecutionTarget')
+
+const pct16 = x => new web3.BigNumber(x).times(new web3.BigNumber(10).toPower(16))
+const createdVoteId = receipt => receipt.logs.filter(x => x.event == 'StartVote')[0].args.votingId
+
+contract('Voting App', accounts => {
+    let app, token, executionTarget = {}
+
+    const votingTime = 1000
+
+    const holder19 = accounts[0]
+    const holder31 = accounts[1]
+    const holder50 = accounts[2]
+    const nonHolder = accounts[4]
+
+    beforeEach(async () => {
+        const n = '0x00'
+        token = await MiniMeToken.new(n, n, 0, 'n', 0, 'n', true)
+
+        await token.generateTokens(holder19, 19)
+        await token.generateTokens(holder31, 31)
+        await token.generateTokens(holder50, 50)
+
+        app = await VotingApp.new()
+        await app.initialize(token.address, pct16(50), pct16(20), votingTime)
+
+        executionTarget = await ExecutionTarget.new()
+    })
+
+    it('deciding voting is automatically executed', async () => {
+        const script = await app.makeSingleScript(executionTarget.address, executionTarget.contract.execute.getData())
+        const votingId = createdVoteId(await app.newVoting(script, { from: holder50 }))
+        assert.equal(await executionTarget.counter(), 1, 'should have received execution call')
+    })
+
+    it('execution scripts can execute multiple actions', async () => {
+        let script = await app.makeSingleScript(executionTarget.address, executionTarget.contract.execute.getData())
+        script = script + script.slice(2) + script.slice(2)
+        const votingId = createdVoteId(await app.newVoting(script, { from: holder50 }))
+        assert.equal(await executionTarget.counter(), 3, 'should have executed multiple times')
+    })
+
+    context('creating vote', () => {
+        let voteId = {}
+        let script = ''
+
+        beforeEach(async () => {
+            script = await app.makeSingleScript(executionTarget.address, executionTarget.contract.execute.getData())
+            script = script + script.slice(2)
+            voteId = createdVoteId(await app.newVoting(script, { from: nonHolder }))
+        })
+
+        it('created vote has correct state', async () => {
+            const [isOpen, isExecuted, creator, startDate, snapshotBlock, y, n, totalVoters, scriptHash, scriptActionsCount] = await app.getVoting(voteId)
+
+            assert.isTrue(isOpen, 'vote should be open')
+            assert.isFalse(isExecuted, 'vote should be executed')
+            assert.equal(creator, nonHolder, 'creator should be correct')
+            assert.equal(snapshotBlock, await getBlockNumber() - 1, 'snapshot block should be correct')
+            assert.equal(y, 0, 'initial yea should be 0')
+            assert.equal(n, 0, 'initial nay should be 0')
+            assert.equal(totalVoters, 100, 'total voters should be 100')
+            assert.equal(scriptHash, sha3(script), 'script hash should be correct')
+            assert.equal(scriptActionsCount, 2)
+        })
+
+        it('holder can vote', async () => {
+            await app.vote(voteId, false, { from: holder31 })
+            const state = await app.getVoting(voteId)
+
+            assert.equal(state[6], 31, 'nay vote should have been counted')
+        })
+
+        it('holder can modify vote', async () => {
+            await app.vote(voteId, false, { from: holder31 })
+            await app.vote(voteId, true, { from: holder31 })
+            const state = await app.getVoting(voteId)
+
+            assert.equal(state[5], 31, 'yea vote should have been counted')
+            assert.equal(state[6], 0, 'nay vote should have been removed')
+        })
+
+        it('token transfers dont affect voting', async () => {
+            await token.transfer(nonHolder, 31, { from: holder31 })
+
+            await app.vote(voteId, true, { from: holder31 })
+            const state = await app.getVoting(voteId)
+
+            assert.equal(state[5], 31, 'yea vote should have been counted')
+            assert.equal(await token.balanceOf(holder31), 0, 'balance should be 0 at current block')
+        })
+
+        it('throws when non-holder votes', async () => {
+            return assertInvalidOpcode(async () => {
+                await app.vote(voteId, true, { from: nonHolder })
+            })
+        })
+
+        it('throws when voting after voting closes', async () => {
+            await timetravel(votingTime + 1)
+            return assertInvalidOpcode(async () => {
+                await app.vote(voteId, true, { from: holder31 })
+            })
+        })
+
+        it('can execute if vote is approved with support and quorum', async () => {
+            await app.vote(voteId, true, { from: holder31 })
+            await app.vote(voteId, false, { from: holder19 })
+            await timetravel(votingTime + 1)
+            await app.executeVote(voteId)
+            assert.equal(await executionTarget.counter(), 2, 'should have executed result')
+        })
+
+        it('cannot execute vote if not enough quorum met', async () => {
+            await app.vote(voteId, true, { from: holder19 })
+            await timetravel(votingTime + 1)
+            return assertInvalidOpcode(async () => {
+                await app.executeVote(voteId)
+            })
+        })
+
+        it('vote is executed automatically if decided', async () => {
+            await app.vote(voteId, true, { from: holder50 }) // causes execution
+            assert.equal(await executionTarget.counter(), 2, 'should have executed result')
+        })
+
+        it('cannot re-execute vote', async () => {
+            await app.vote(voteId, true, { from: holder50 }) // causes execution
+            return assertInvalidOpcode(async () => {
+                await app.executeVote(voteId)
+            })
+        })
+
+        it('cannot vote on executed vote', async () => {
+            await app.vote(voteId, true, { from: holder50 }) // causes execution
+            return assertInvalidOpcode(async () => {
+                await app.vote(voteId, true, { from: holder19 })
+            })
+        })
+    })
+})

--- a/test/helpers/ExecutionTarget.sol
+++ b/test/helpers/ExecutionTarget.sol
@@ -1,0 +1,13 @@
+pragma solidity 0.4.15;
+
+contract ExecutionTarget {
+    uint public counter;
+
+    function execute() {
+        counter += 1;
+    }
+
+    function setCounter(uint x) {
+        counter = x;
+    }
+}


### PR DESCRIPTION
Implements the new voting app for v0.5 in which the app is its own identity (no need to have individual vote contracts any more).

In this initial implementation no voting metadata is saved on chain. Should we include any? Should that be a string saved on-chain or a reference to a content addressable document in IPFS or Swarm? cc @luisivan 

What a voting will execute is determined by its `executionScript`.  The script allows multiple actions to be voted in just one voting allowing more complex workflows.

A script is just a bytes array that contains an arbitrary number of (destination address, calldata) pairs. When executed, the voting app will do as many `CALL` as specified in the script. In case one of the calls fails or it goes out of gas, the entire execution is reverted.

The script idea was inspired by: https://github.com/reverendus/tx-manager/blob/master/src/tx.sol