### PR TITLE
Remove factory script

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Core contracts for Aragon",
   "main": "index.js",
   "scripts": {
-    "generate:factory": "truffle exec scripts/generate_factory.js",
     "test": "truffle test",
     "lint": "solium --dir ./contracts",
     "coverage": "scripts/coverage.sh",


### PR DESCRIPTION
Based on the new repo structure, the script generating the factory has been removed, just cleaning the command using it.