### PR TITLE
Expose artifacts and contracts

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,23 @@
 var glob = require('glob')
 var path = require('path')
-var basePath = './artifacts'
 
-module.exports = glob.sync(
-  path.resolve(__dirname, basePath, '*.json')
+var artifactsBasePath = './artifacts'
+var contractsBasePath = './build/contracts'
+
+module.exports.artifacts = glob.sync(
+  path.resolve(__dirname, artifactsBasePath, '*.json')
+).reduce(function (artifacts, file) {
+  var artifact = require(file)
+
+  if (artifact.id) {
+    artifacts[artifact.id] = artifact
+  }
+
+  return artifacts
+}, {})
+
+module.exports.contracts = glob.sync(
+  path.resolve(__dirname, contractsBasePath, '*.json')
 ).reduce(function (contracts, file) {
   var contract = require(file)
 


### PR DESCRIPTION
The published package will now expose two objects:

- ``artifacts`` which is an object of generated artifacts (defined in #110), where the key is the artifact ID
- ``contracts`` which is the built truffle contracts, where the key is the contract name