### PR TITLE
Split Token Manager initializers based on mode

### DIFF
--- a/contracts/apps/token-manager/TokenManager.sol
+++ b/contracts/apps/token-manager/TokenManager.sol
@@ -48,11 +48,23 @@ contract TokenManager is App, Initializable, TokenController, EVMCallScriptRunne
     event RevokeVesting(address indexed receiver, uint256 vestingId);
 
     /**
-    * @notice Initializes TokenManager (parameters won't be modifiable after being set)
+    * @notice Initializes TokenManager in native mode (parameters won't be modifiable after being set)
+    * @param _token MiniMeToken address for the managed token (token manager must be the token controller)
+    */
+    function initializeNative(MiniMeToken _token) onlyInit {
+        _initialize(_token, ERC20(0));
+    }
+
+    /**
+    * @notice Initializes TokenManager in wrapper mode (parameters won't be modifiable after being set)
     * @param _token MiniMeToken address for the managed token (token manager must be the token controller)
     * @param _wrappedToken Address of the token being wrapped (can get 1:1 token exchanged for managed token)
     */
-    function initialize(MiniMeToken _token, ERC20 _wrappedToken) onlyInit {
+    function initializeWrapper(MiniMeToken _token, ERC20 _wrappedToken) onlyInit {
+        _initialize(_token, _wrappedToken);
+    }
+
+    function _initialize(MiniMeToken _token, ERC20 _wrappedToken) internal {
         initialized();
 
         require(_token.controller() == address(this));

--- a/test/apps_fundraising.js
+++ b/test/apps_fundraising.js
@@ -21,7 +21,7 @@ contract('Fundraising', accounts => {
         token = await MiniMeToken.new(n, n, 0, 'n', 0, 'n', true)
         tokenManager = await TokenManager.new()
         await token.changeController(tokenManager.address)
-        await tokenManager.initialize(token.address, n)
+        await tokenManager.initializeNative(token.address)
 
         fundraising = await FundraisingApp.new()
         await fundraising.initialize(tokenManager.address, vault)

--- a/test/apps_tokenmanager.js
+++ b/test/apps_tokenmanager.js
@@ -15,13 +15,19 @@ contract('Token Manager', accounts => {
     beforeEach(async () => {
         token = await MiniMeToken.new(n, n, 0, 'n', 0, 'n', true)
         tokenManager = await TokenManager.new()
-        await token.changeController(tokenManager.address)
+    })
+
+    it('fails when initializing without setting controller', async () => {
+        return assertInvalidOpcode(async () => {
+            await tokenManager.initializeNative(token.address)
+        })
     })
 
     context('for native tokens', () => {
         const holder = accounts[1]
 
         beforeEach(async () => {
+            await token.changeController(tokenManager.address)
             await tokenManager.initializeNative(token.address)
         })
 
@@ -162,6 +168,7 @@ contract('Token Manager', accounts => {
             wrappedToken = await MiniMeToken.new(n, n, 0, 'n', 0, 'n', true)
             await wrappedToken.generateTokens(holder100, 100)
 
+            await token.changeController(tokenManager.address)
             await tokenManager.initializeWrapper(token.address, wrappedToken.address)
         })
 

--- a/test/apps_tokenmanager.js
+++ b/test/apps_tokenmanager.js
@@ -72,6 +72,14 @@ contract('Token Manager', accounts => {
             })
         })
 
+        it('fails when assigning invalid vesting schedule', async () => {
+            return assertInvalidOpcode(async () => {
+                const tokens = 10
+                // vesting < cliff
+                await tokenManager.assignVested(holder, tokens, 10, 20, 10, true)
+            })
+        })
+
         context('assigning vested tokens', () => {
             let now = 0
 

--- a/test/apps_tokenmanager.js
+++ b/test/apps_tokenmanager.js
@@ -22,7 +22,7 @@ contract('Token Manager', accounts => {
         const holder = accounts[1]
 
         beforeEach(async () => {
-            await tokenManager.initialize(token.address, n)
+            await tokenManager.initializeNative(token.address)
         })
 
         it('can mint tokens', async () => {
@@ -162,7 +162,7 @@ contract('Token Manager', accounts => {
             wrappedToken = await MiniMeToken.new(n, n, 0, 'n', 0, 'n', true)
             await wrappedToken.generateTokens(holder100, 100)
 
-            await tokenManager.initialize(token.address, wrappedToken.address)
+            await tokenManager.initializeWrapper(token.address, wrappedToken.address)
         })
 
         it('cannot wrap more than allowance', async () => {


### PR DESCRIPTION
Creates two different initializers for the two modes a Token Manager can be in.