### PR TITLE
Adapt tests for Byzantium revert's and remove pre-Byzantium logic from DelegateProxy

### DIFF
--- a/contracts/common/DelegateProxy.sol
+++ b/contracts/common/DelegateProxy.sol
@@ -1,40 +1,25 @@
 pragma solidity 0.4.15;
 
 contract DelegateProxy {
-    bool constant IS_BYZANTIUM = false;
-
-    // TODO: Remove pre-byzantium logic after tools have new opcodes
-
     /**
     * @dev Performs a delegatecall and returns whatever the delegatecall returned (entire context execution will return!)
     * @param _dst Destination address to perform the delegatecall
     * @param _calldata Calldata for the delegatecall
     */
     function delegatedFwd(address _dst, bytes _calldata) internal {
-        uint useByzantiumOpcodes = IS_BYZANTIUM ? 1 : 0;
         assembly {
             switch extcodesize(_dst) case 0 { revert(0, 0) }
 
-            switch useByzantiumOpcodes
-            case 0 {
-                // This code block will be removed
-                let len := 4096
-                let result := delegatecall(sub(gas, 10000), _dst, add(_calldata, 0x20), mload(_calldata), 0, len)
-                switch result case 0 { invalid() }
-                return (0, len)
-            }
-            default {
-                let result := delegatecall(sub(gas, 10000), _dst, add(_calldata, 0x20), mload(_calldata), 0, 0)
-                let size := returndatasize
+            let result := delegatecall(sub(gas, 10000), _dst, add(_calldata, 0x20), mload(_calldata), 0, 0)
+            let size := returndatasize
 
-                let ptr := mload(0x40)
-                returndatacopy(ptr, 0, size)
+            let ptr := mload(0x40)
+            returndatacopy(ptr, 0, size)
 
-                // revert instead of invalid() bc if the underlying call failed with invalid() it already wasted gas.
-                // if the call returned error data, forward it
-                switch result case 0 { revert(ptr, size) }
-                default { return(ptr, size) }
-            }
+            // revert instead of invalid() bc if the underlying call failed with invalid() it already wasted gas.
+            // if the call returned error data, forward it
+            switch result case 0 { revert(ptr, size) }
+            default { return(ptr, size) }
         }
     }
 }

--- a/contracts/common/EtherToken.sol
+++ b/contracts/common/EtherToken.sol
@@ -34,6 +34,7 @@ contract EtherToken is ERC677Token {
 
     function withdraw(address _recipient, uint256 _amount) {
         require(_amount > 0);
+        require(balances[msg.sender] >= _amount);
 
         totalSupply = totalSupply.sub(_amount);
         balances[msg.sender] = balances[msg.sender].sub(_amount); // fails if no balance

--- a/contracts/zeppelin/token/BasicToken.sol
+++ b/contracts/zeppelin/token/BasicToken.sol
@@ -21,6 +21,7 @@ contract BasicToken is ERC20Basic {
   */
   function transfer(address _to, uint256 _value) public returns (bool) {
     require(_to != address(0));
+    require(_value <= balances[msg.sender]);
 
     // SafeMath.sub will throw if there is not enough balance.
     balances[msg.sender] = balances[msg.sender].sub(_value);

--- a/contracts/zeppelin/token/StandardToken.sol
+++ b/contracts/zeppelin/token/StandardToken.sol
@@ -14,7 +14,7 @@ import './ERC20.sol';
  */
 contract StandardToken is ERC20, BasicToken {
 
-  mapping (address => mapping (address => uint256)) allowed;
+  mapping (address => mapping (address => uint256)) internal allowed;
 
 
   /**
@@ -25,15 +25,12 @@ contract StandardToken is ERC20, BasicToken {
    */
   function transferFrom(address _from, address _to, uint256 _value) public returns (bool) {
     require(_to != address(0));
-
-    uint256 _allowance = allowed[_from][msg.sender];
-
-    // Check is not needed because sub(_allowance, _value) will already throw if this condition is not met
-    // require (_value <= _allowance);
+    require(_value <= balances[_from]);
+    require(_value <= allowed[_from][msg.sender]);
 
     balances[_from] = balances[_from].sub(_value);
     balances[_to] = balances[_to].add(_value);
-    allowed[_from][msg.sender] = _allowance.sub(_value);
+    allowed[_from][msg.sender] = allowed[_from][msg.sender].sub(_value);
     Transfer(_from, _to, _value);
     return true;
   }
@@ -70,15 +67,13 @@ contract StandardToken is ERC20, BasicToken {
    * the first transaction is mined)
    * From MonolithDAO Token.sol
    */
-  function increaseApproval (address _spender, uint _addedValue)
-    returns (bool success) {
+  function increaseApproval (address _spender, uint _addedValue) public returns (bool success) {
     allowed[msg.sender][_spender] = allowed[msg.sender][_spender].add(_addedValue);
     Approval(msg.sender, _spender, allowed[msg.sender][_spender]);
     return true;
   }
 
-  function decreaseApproval (address _spender, uint _subtractedValue)
-    returns (bool success) {
+  function decreaseApproval (address _spender, uint _subtractedValue) public returns (bool success) {
     uint oldValue = allowed[msg.sender][_spender];
     if (_subtractedValue > oldValue) {
       allowed[msg.sender][_spender] = 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2164,21 +2164,20 @@
       }
     },
     "ethereumjs-testrpc": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/ethereumjs-testrpc/-/ethereumjs-testrpc-4.1.3.tgz",
-      "integrity": "sha1-dNuQyQdf36O6JRPwhZW6rDaobH4=",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-testrpc/-/ethereumjs-testrpc-6.0.1.tgz",
+      "integrity": "sha1-CdoVoUox2jhPsQwIwPqaxXasgTc=",
       "dev": true,
       "requires": {
         "webpack": "3.6.0"
       }
     },
     "ethereumjs-testrpc-sc": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/ethereumjs-testrpc-sc/-/ethereumjs-testrpc-sc-4.0.3.tgz",
-      "integrity": "sha512-iDMj2wXCbBKBkHbjt9RuBnEun2RkFyyyTjj11aJZZVP4Bt6v9GUKOrMJXcHr3qIxCMX+CjWqw8qKk3SIa8b+3Q==",
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/ethereumjs-testrpc-sc/-/ethereumjs-testrpc-sc-6.0.7.tgz",
+      "integrity": "sha512-6X/FknTe702L0UGtJ3V3qlh6HNavJkuuRxB18fbITOuOyvCike7O5TVYOthqyCdxgW+ZW/FQGtFpoKeuRZnbNg==",
       "dev": true,
       "requires": {
-        "ethereumjs-vm": "git+https://github.com/sc-forks/ethereumjs-vm-sc.git#0aa274178f0a257ae76436fe16b1ad18b8cf2725",
         "webpack": "3.6.0"
       }
     },
@@ -3539,9 +3538,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
-      "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
+      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
         "async": "1.5.2",
@@ -4016,7 +4015,7 @@
         "escodegen": "1.8.1",
         "esprima": "2.7.3",
         "glob": "5.0.15",
-        "handlebars": "4.0.10",
+        "handlebars": "4.0.11",
         "js-yaml": "3.6.1",
         "mkdirp": "0.5.1",
         "nopt": "3.0.6",
@@ -6011,21 +6010,19 @@
       }
     },
     "solidity-coverage": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.2.4.tgz",
-      "integrity": "sha512-5PUmjViUzPRFmMBTLrHBIXSZoFhR6ErzVbGmarjdvoT/W2mlEPrfXWuAN9NLouwdZUsVW8BtSsGOhhzi7lhv4w==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/solidity-coverage/-/solidity-coverage-0.3.5.tgz",
+      "integrity": "sha512-ZAzYfC9FVix3iqBbJyYow6EPxZevkUlEp0mjJ7b1bM7HWFjoPeoUowUq7nbYECP9WVOElakX6GLewJsIQern5w==",
       "dev": true,
       "requires": {
-        "commander": "2.11.0",
         "death": "1.1.0",
-        "ethereumjs-testrpc-sc": "4.0.3",
+        "ethereumjs-testrpc-sc": "6.0.7",
         "istanbul": "0.4.5",
         "keccakjs": "0.2.1",
-        "mkdirp": "0.5.1",
         "req-cwd": "1.0.1",
         "shelljs": "0.7.8",
         "sol-explore": "1.6.2",
-        "solidity-parser": "git+https://github.com/sc-forks/solidity-parser.git#4f6b796c49393aa68b2fc2a35e52959015d102bd",
+        "solidity-parser-sc": "0.4.1",
         "web3": "0.18.4"
       },
       "dependencies": {
@@ -6033,8 +6030,10 @@
           "version": "git+https://github.com/debris/bignumber.js.git#94d7146671b9719e00a09c29b01a691bc85048c2",
           "dev": true
         },
-        "solidity-parser": {
-          "version": "git+https://github.com/sc-forks/solidity-parser.git#4f6b796c49393aa68b2fc2a35e52959015d102bd",
+        "solidity-parser-sc": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/solidity-parser-sc/-/solidity-parser-sc-0.4.1.tgz",
+          "integrity": "sha512-51kDgZXLCfgOtmxrPPK1Jhgi257emdf8g9xBA7BA5TgFTM8tSEgRzvJGlGTPbI03txLETuSvNpPhy46c+srOyQ==",
           "dev": true,
           "requires": {
             "mocha": "2.5.3",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
     "babel-preset-stage-3": "^6.17.0",
     "babel-register": "^6.26.0",
     "coveralls": "^2.13.1",
-    "ethereumjs-testrpc": "^4.1.3",
+    "ethereumjs-testrpc": "^6.0.1",
     "mocha-lcov-reporter": "^1.3.0",
-    "solidity-coverage": "^0.2.3",
+    "solidity-coverage": "^0.3.5",
     "solidity-inspector": "^0.2.3",
     "solidity-sha3": "^0.4.1",
     "truffle": "^3.4.9"

--- a/test/ether_token.js
+++ b/test/ether_token.js
@@ -1,4 +1,4 @@
-const { assertInvalidOpcode } = require('./helpers/assertThrow')
+const { assertRevert } = require('./helpers/assertThrow')
 const { getBalance } = require('./helpers/web3')
 const EtherToken = artifacts.require('EtherToken')
 const ERC677Stub = artifacts.require('ERC677Stub')
@@ -14,7 +14,7 @@ contract('EtherToken', accounts => {
   })
 
   it('fails when wrapping 0', async () => {
-    return assertInvalidOpcode(async () => {
+    return assertRevert(async () => {
         await token.wrap({ value: 0 })
     })
   })
@@ -78,13 +78,13 @@ contract('EtherToken', accounts => {
       })
 
       it('fails when withdrawing more than balance', async () => {
-        return assertInvalidOpcode(async () => {
+        return assertRevert(async () => {
             await token.withdraw(withdrawAddr, value + 1)
         })
       })
 
       it('fails when withdrawing 0', async () => {
-        return assertInvalidOpcode(async () => {
+        return assertRevert(async () => {
             await token.withdraw(withdrawAddr, 0)
         })
       })

--- a/test/evm_call_script.js
+++ b/test/evm_call_script.js
@@ -1,4 +1,4 @@
-const { assertInvalidOpcode } = require('./helpers/assertThrow')
+const { assertRevert } = require('./helpers/assertThrow')
 const { encodeScript } = require('./helpers/evmScript')
 const ExecutionTarget = artifacts.require('ExecutionTarget')
 const Executor = artifacts.require('Executor')
@@ -61,7 +61,7 @@ contract('EVM call script', accounts => {
 
         const script = encodeScript([action1, action2])
 
-        return assertInvalidOpcode(async () => {
+        return assertRevert(async () => {
             await executor.execute(script)
         })
     })

--- a/test/helpers/assertThrow.js
+++ b/test/helpers/assertThrow.js
@@ -1,22 +1,26 @@
 function assertError(error, s, message) {
-  assert.isAbove(error.message.search(s), -1, message);
+    assert.isAbove(error.message.search(s), -1, message);
 }
 
 async function assertThrows(block, message, errorCode) {
-      try {
-          await block()
-      } catch (e) {
-          return assertError(e, errorCode, message)
-      }
-      assert.fail('should have thrown before')
+    try {
+        await block()
+    } catch (e) {
+        return assertError(e, errorCode, message)
+    }
+    assert.fail('should have thrown before')
 }
 
 module.exports = {
-  async assertJump(block, message = 'should have failed with invalid JUMP') {
-    return assertThrows(block, message, 'invalid JUMP')
-  },
+    async assertJump(block, message = 'should have failed with invalid JUMP') {
+        return assertThrows(block, message, 'invalid JUMP')
+    },
 
-  async assertInvalidOpcode(block, message = 'should have failed with invalid opcode') {
-    return assertThrows(block, message, 'invalid opcode')
-  }
+    async assertInvalidOpcode(block, message = 'should have failed with invalid opcode') {
+        return assertThrows(block, message, 'invalid opcode')
+    },
+
+    async assertRevert(block, message = 'should have failed by reverting') {
+        return assertThrows(block, message, 'revert')
+    },
 }

--- a/test/kernel_acl.js
+++ b/test/kernel_acl.js
@@ -1,4 +1,4 @@
-const { assertInvalidOpcode } = require('./helpers/assertThrow')
+const { assertRevert } = require('./helpers/assertThrow')
 const Kernel = artifacts.require('Kernel')
 const KernelProxy = artifacts.require('KernelProxy')
 const { getBlockNumber } = require('./helpers/web3')
@@ -28,7 +28,7 @@ contract('Kernel ACL', accounts => {
     })
 
     it('throws on reinitialization', async () => {
-        return assertInvalidOpcode(async () => {
+        return assertRevert(async () => {
             await kernel.initialize(accounts[0])
         })
     })
@@ -38,7 +38,7 @@ contract('Kernel ACL', accounts => {
     })
 
     it('protected actions fail if not allowed', async () => {
-        return assertInvalidOpcode(async () => {
+        return assertRevert(async () => {
             await kernel.upgradeKernel(accounts[0])
         })
     })
@@ -75,19 +75,19 @@ contract('Kernel ACL', accounts => {
         })
 
         it('root cannot revoke permission', async () => {
-            return assertInvalidOpcode(async () => {
+            return assertRevert(async () => {
                 await kernel.revokePermission(granted, app, role, { from: permissionsRoot })
             })
         })
 
         it('root cannot re-create permission', async () => {
-            return assertInvalidOpcode(async () => {
+            return assertRevert(async () => {
                 await kernel.createPermission(granted, app, role, granted, { from: permissionsRoot })
             })
         })
 
         it('root cannot grant permission', async () => {
-            return assertInvalidOpcode(async () => {
+            return assertRevert(async () => {
                 await kernel.grantPermission(granted, app, role, granted, { from: permissionsRoot })
             })
         })
@@ -117,7 +117,7 @@ contract('Kernel ACL', accounts => {
             })
 
             it('child cannot re-grant permission', async () => {
-                return assertInvalidOpcode(async () => {
+                return assertRevert(async () => {
                     await kernel.grantPermission(accounts[7], app, role, child, { from: child })
                 })
             })
@@ -128,7 +128,7 @@ contract('Kernel ACL', accounts => {
             })
 
             it('cannot be reset to change parent', async () => {
-                return assertInvalidOpcode(async () => {
+                return assertRevert(async () => {
                     await kernel.grantPermission(child, app, role, accounts[7], { from: granted })
                 })
             })

--- a/test/kernel_apps.js
+++ b/test/kernel_apps.js
@@ -1,4 +1,4 @@
-const { assertInvalidOpcode } = require('./helpers/assertThrow')
+const { assertRevert } = require('./helpers/assertThrow')
 const { hash } = require('eth-ens-namehash')
 const Kernel = artifacts.require('Kernel')
 const AppProxy = artifacts.require('AppProxy')
@@ -27,7 +27,7 @@ contract('Kernel apps', accounts => {
     })
 
     it('throws if using app without reference in kernel', async () => {
-        return assertInvalidOpcode(async () => {
+        return assertRevert(async () => {
             await app.setValue(10)
         })
     })
@@ -43,7 +43,7 @@ contract('Kernel apps', accounts => {
         })
 
         it('throws when called by unauthorized entity', async () => {
-            return assertInvalidOpcode(async () => {
+            return assertRevert(async () => {
                 await app.setValue(10, { from: accounts[1] })
             })
         })
@@ -58,7 +58,7 @@ contract('Kernel apps', accounts => {
         it('can update app code and removed functions throw', async () => {
             await app.setValue(10)
             await kernel.setAppCode(appId, appCode2.address)
-            return assertInvalidOpcode(async () => {
+            return assertRevert(async () => {
                 await app.setValue(10)
             })
         })

--- a/test/kernel_upgrade.js
+++ b/test/kernel_upgrade.js
@@ -1,4 +1,4 @@
-const { assertInvalidOpcode } = require('./helpers/assertThrow')
+const { assertRevert } = require('./helpers/assertThrow')
 const Kernel = artifacts.require('Kernel')
 const KernelProxy = artifacts.require('KernelProxy')
 const UpgradedKernel = artifacts.require('UpgradedKernel')
@@ -16,13 +16,13 @@ contract('Kernel Upgrade', accounts => {
     })
 
     it('fails to upgrade kernel without permission', async () => {
-        return assertInvalidOpcode(async () => {
+        return assertRevert(async () => {
             await kernel.upgradeKernel(accounts[0])
         })
     })
 
     it('fails when calling is upgraded on old version', async () => {
-        return assertInvalidOpcode(async () => {
+        return assertRevert(async () => {
             await UpgradedKernel.at(kernel.address).isUpgraded()
         })
     })

--- a/test/mini_me_token.js
+++ b/test/mini_me_token.js
@@ -1,5 +1,5 @@
 const { getBlockNumber, getBlock, getBalance } = require('./helpers/web3')
-const { assertInvalidOpcode } = require('./helpers/assertThrow')
+const { assertRevert } = require('./helpers/assertThrow')
 const MiniMeToken = artifacts.require('MiniMeToken')
 const MiniMeTokenFactory = artifacts.require('MiniMeTokenFactory')
 
@@ -40,7 +40,7 @@ contract('MiniMeToken', accounts => {
             assert.equal(await token.totalSupplyAt(block - 1), 100, 'total supply should be 100 in previous block')
             assert.equal(await token.balanceOf(accounts[1]), 80, 'should have destroyed 20 tokens from orignal amount')
 
-            return assertInvalidOpcode(async () => {
+            return assertRevert(async () => {
                 await token.destroyTokens(accounts[2], 100)
             })
         })
@@ -79,14 +79,14 @@ contract('MiniMeToken', accounts => {
         it('claim tokens', async () => {
             assert.ok(await token.claimTokens(0x0))
             assert.ok(await token.claimTokens(token.address))
-            return assertInvalidOpcode(async () => {
+            return assertRevert(async () => {
                 await token.transfer(token.address, 5)
             })
         })
 
         it('disable transfers', async () => {
             token.enableTransfers(false)
-            return assertInvalidOpcode(async () => {
+            return assertRevert(async () => {
                 await token.transfer(accounts[3], 5)
             })
         })
@@ -101,7 +101,7 @@ contract('MiniMeToken', accounts => {
             assert.equal(allowance, 10, 'should now have an allowance of 5')
 
             await token.enableTransfers(false)
-            return assertInvalidOpcode(async () => {
+            return assertRevert(async () => {
                 await token.approve(accounts[2], 10)
             })
         })

--- a/test/zeppelin_StandardToken.js
+++ b/test/zeppelin_StandardToken.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const assertJump = function(error) {
-  assert.isAbove(error.message.search('invalid opcode'), -1, 'Invalid opcode error must be returned');
+  assert.isAbove(error.message.search('revert'), -1, 'Revert should have occurred');
 }
 
 var StandardTokenMock = artifacts.require('./helpers/StandardTokenMock.sol');


### PR DESCRIPTION
Also updates Zeppelin's token contracts to the latest version to avoid failure with SafeMath assertions