### PR TITLE
Add ability to execute initialization payload on AppProxy deployment

### DIFF
--- a/contracts/apps/AppProxy.sol
+++ b/contracts/apps/AppProxy.sol
@@ -4,9 +4,25 @@ import "./AppStorage.sol";
 import "../common/DelegateProxy.sol";
 
 contract AppProxy is AppStorage, DelegateProxy {
-    function AppProxy(IKernel _kernel, bytes32 _appId) {
+    /**
+    * @dev Initialize AppProxy
+    * @param _kernel Reference to organization kernel for the app
+    * @param _appId Identifier for app
+    * @param _initializePayload Payload for call to be made after setup to initialize
+    */
+    function AppProxy(IKernel _kernel, bytes32 _appId, bytes _initializePayload) {
         kernel = _kernel;
         appId = _appId;
+
+        // If initialize payload is provided, it will be executed
+        if (_initializePayload.length > 0) {
+            address appCode = kernel.getAppCode(appId);
+            require(isContract(appCode));
+            // Cannot make delegatecall as a delegateproxy.delegatedFwd as it
+            // returns ending execution context and halts contract deployment
+            require(appCode.delegatecall(_initializePayload));
+        }
+
     }
 
     function () payable public {

--- a/contracts/common/DelegateProxy.sol
+++ b/contracts/common/DelegateProxy.sol
@@ -7,9 +7,8 @@ contract DelegateProxy {
     * @param _calldata Calldata for the delegatecall
     */
     function delegatedFwd(address _dst, bytes _calldata) internal {
+        require(isContract(_dst));
         assembly {
-            switch extcodesize(_dst) case 0 { revert(0, 0) }
-
             let result := delegatecall(sub(gas, 10000), _dst, add(_calldata, 0x20), mload(_calldata), 0, 0)
             let size := returndatasize
 
@@ -21,5 +20,11 @@ contract DelegateProxy {
             switch result case 0 { revert(ptr, size) }
             default { return(ptr, size) }
         }
+    }
+
+    function isContract(address _target) constant internal returns (bool) {
+        uint256 size;
+        assembly { size := extcodesize(_target) }
+        return size > 0;
     }
 }

--- a/test/mocks/AppStub.sol
+++ b/test/mocks/AppStub.sol
@@ -4,10 +4,17 @@ import "../../contracts/apps/App.sol";
 
 contract AppSt {
     uint a;
+    bool public initialized;
 }
 
 contract AppStub is App, AppSt {
     bytes32 constant public ROLE = bytes32(1);
+
+    function initialize() {
+        require(!initialized);
+        initialized = true;
+    }
+
     function setValue(uint i) auth(ROLE) {
         a = i;
     }


### PR DESCRIPTION
Closes #144 

Adds the ability to provide a payload to be executed when an AppProxy is deployed. This allows to perform an atomic deployment and initialization of any app without the need to have a specific factory.

It shouldn't introduce any security vulnerabilities as the proxy will forward any call in the same way after it being deployed.

**TODO:** Needs documentation update on the wiki