### PR TITLE
Allow loose solidity versions for interfaces and files imported by apps

### DIFF
--- a/contracts/apps/App.sol
+++ b/contracts/apps/App.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity ^0.4.15;
 
 import "./AppStorage.sol";
 

--- a/contracts/apps/AppStorage.sol
+++ b/contracts/apps/AppStorage.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity ^0.4.15;
 
 import "../kernel/IKernel.sol";
 

--- a/contracts/common/EVMCallScript.sol
+++ b/contracts/common/EVMCallScript.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity ^0.4.15;
 
 // Inspired by https://github.com/reverendus/tx-manager
 
@@ -12,7 +12,7 @@ contract EVMCallScriptRunner {
             uint256 calldataLength = uint256(uint32At(script, location + 0x14));
             uint256 calldataStart = locationOf(script, location + 0x14 + 0x04);
             uint8 ok;
-            
+
             // logged before execution to ensure event ordering in receipt
             // if failed entire execution is reverted regardless
             LogScriptCall(msg.sender, address(this), contractAddress);

--- a/contracts/common/EtherToken.sol
+++ b/contracts/common/EtherToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity ^0.4.15;
 
 import "./erc677/ERC677Token.sol";
 

--- a/contracts/common/IForwarder.sol
+++ b/contracts/common/IForwarder.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity ^0.4.15;
 
 contract IForwarder {
     function isForwarder() public constant returns (bool) { return true; }

--- a/contracts/common/Initializable.sol
+++ b/contracts/common/Initializable.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity ^0.4.15;
 
 contract Initializable {
     uint256 private initializationBlock;

--- a/contracts/common/MiniMeToken.sol
+++ b/contracts/common/MiniMeToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.6;
+pragma solidity ^0.4.15;
 
 /*
     Copyright 2016, Jordi Baylina

--- a/contracts/common/TokenController.sol
+++ b/contracts/common/TokenController.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity ^0.4.15;
 
 /// @dev The token controller contract must implement these functions
 contract TokenController {

--- a/contracts/kernel/IKernel.sol
+++ b/contracts/kernel/IKernel.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity ^0.4.15;
 
 contract IKernel {
     event SetPermission(address indexed entity, address indexed app, bytes32 indexed role, bool allowed);

--- a/contracts/misc/Migrations.sol
+++ b/contracts/misc/Migrations.sol
@@ -1,5 +1,4 @@
-pragma solidity ^0.4.2;
-
+pragma solidity 0.4.15;
 
 contract Migrations {
     address public owner;

--- a/contracts/zeppelin/math/Math.sol
+++ b/contracts/zeppelin/math/Math.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity 0.4.15;
 
 /**
  * @title Math

--- a/contracts/zeppelin/math/SafeMath.sol
+++ b/contracts/zeppelin/math/SafeMath.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity 0.4.15;
 
 
 /**

--- a/contracts/zeppelin/token/BasicToken.sol
+++ b/contracts/zeppelin/token/BasicToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity 0.4.15;
 
 
 import './ERC20Basic.sol';

--- a/contracts/zeppelin/token/ERC20Basic.sol
+++ b/contracts/zeppelin/token/ERC20Basic.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity ^0.4.15;
 
 
 /**

--- a/contracts/zeppelin/token/StandardToken.sol
+++ b/contracts/zeppelin/token/StandardToken.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.11;
+pragma solidity 0.4.15;
 
 
 import './BasicToken.sol';


### PR DESCRIPTION
Closes #158 

- Requires a specific solc version (`0.4.15`) in critical core contracts (Kernel, AppProxy, etc.)
- Allows a loose solc version (`^0.4.15`) in contracts that are meant to be imported by app developers, so they can use other versions of solc.