### PR TITLE
solc update to 0.4.18 (use view and pure 🎉)

### DIFF
--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -2,7 +2,9 @@
     "extends": "solium:all",
     "plugins": ["security"],
     "rules": {
+        "security/no-low-level-calls": "off",
         "security/no-inline-assembly": "off",
+        "function-order": "off",
         "imports-on-top": 1,
         "variable-declarations": 1,
         "array-declarations": 1,

--- a/contracts/apps/App.sol
+++ b/contracts/apps/App.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.4.18;
 
 import "./AppStorage.sol";
 
+
 contract App is AppStorage {
     modifier auth(bytes32 _role) {
         require(canPerform(msg.sender, _role));

--- a/contracts/apps/App.sol
+++ b/contracts/apps/App.sol
@@ -8,7 +8,7 @@ contract App is AppStorage {
         _;
     }
 
-    function canPerform(address _sender, bytes32 _role) public constant returns (bool) {
+    function canPerform(address _sender, bytes32 _role) public view returns (bool) {
         return address(kernel) == 0 || kernel.hasPermission(_sender, address(this), _role);
     }
 }

--- a/contracts/apps/App.sol
+++ b/contracts/apps/App.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity ^0.4.18;
 
 import "./AppStorage.sol";
 

--- a/contracts/apps/AppProxy.sol
+++ b/contracts/apps/AppProxy.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 
 import "./AppStorage.sol";
 import "../common/DelegateProxy.sol";
@@ -22,7 +22,6 @@ contract AppProxy is AppStorage, DelegateProxy {
             // returns ending execution context and halts contract deployment
             require(appCode.delegatecall(_initializePayload));
         }
-
     }
 
     function () payable public {

--- a/contracts/apps/AppProxy.sol
+++ b/contracts/apps/AppProxy.sol
@@ -3,6 +3,7 @@ pragma solidity 0.4.18;
 import "./AppStorage.sol";
 import "../common/DelegateProxy.sol";
 
+
 contract AppProxy is AppStorage, DelegateProxy {
     /**
     * @dev Initialize AppProxy

--- a/contracts/apps/AppStorage.sol
+++ b/contracts/apps/AppStorage.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.4.18;
 
 import "../kernel/IKernel.sol";
 
+
 contract AppStorage {
     IKernel public kernel;
     bytes32 public appId;

--- a/contracts/apps/AppStorage.sol
+++ b/contracts/apps/AppStorage.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity ^0.4.18;
 
 import "../kernel/IKernel.sol";
 

--- a/contracts/common/DelegateProxy.sol
+++ b/contracts/common/DelegateProxy.sol
@@ -22,7 +22,7 @@ contract DelegateProxy {
         }
     }
 
-    function isContract(address _target) constant internal returns (bool) {
+    function isContract(address _target) internal view returns (bool) {
         uint256 size;
         assembly { size := extcodesize(_target) }
         return size > 0;

--- a/contracts/common/DelegateProxy.sol
+++ b/contracts/common/DelegateProxy.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 
 contract DelegateProxy {
     /**

--- a/contracts/common/DelegateProxy.sol
+++ b/contracts/common/DelegateProxy.sol
@@ -1,5 +1,6 @@
 pragma solidity 0.4.18;
 
+
 contract DelegateProxy {
     /**
     * @dev Performs a delegatecall and returns whatever the delegatecall returned (entire context execution will return!)

--- a/contracts/common/EVMCallScript.sol
+++ b/contracts/common/EVMCallScript.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity ^0.4.18;
 
 // Inspired by https://github.com/reverendus/tx-manager
 
@@ -12,7 +12,7 @@ contract EVMCallScriptRunner {
             uint256 calldataLength = uint256(uint32At(script, location + 0x14));
             uint256 calldataStart = locationOf(script, location + 0x14 + 0x04);
             uint8 ok;
-            
+
             // logged before execution to ensure event ordering in receipt
             // if failed entire execution is reverted regardless
             LogScriptCall(msg.sender, address(this), contractAddress);

--- a/contracts/common/EVMCallScript.sol
+++ b/contracts/common/EVMCallScript.sol
@@ -26,13 +26,13 @@ contract EVMCallScriptRunner {
         }
     }
 
-    function uint256At(bytes data, uint256 location) internal returns (uint256 result) {
+    function uint256At(bytes data, uint256 location) internal pure returns (uint256 result) {
         assembly {
             result := mload(add(data, add(0x20, location)))
         }
     }
 
-    function addressAt(bytes data, uint256 location) internal returns (address result) {
+    function addressAt(bytes data, uint256 location) internal pure returns (address result) {
         uint256 word = uint256At(data, location);
 
         assembly {
@@ -41,7 +41,7 @@ contract EVMCallScriptRunner {
         }
     }
 
-    function uint32At(bytes data, uint256 location) internal returns (uint32 result) {
+    function uint32At(bytes data, uint256 location) internal pure returns (uint32 result) {
         uint256 word = uint256At(data, location);
 
         assembly {
@@ -50,7 +50,7 @@ contract EVMCallScriptRunner {
         }
     }
 
-    function locationOf(bytes data, uint256 location) internal returns (uint256 result) {
+    function locationOf(bytes data, uint256 location) internal pure returns (uint256 result) {
         assembly {
             result := add(data, add(0x20, location))
         }
@@ -58,7 +58,7 @@ contract EVMCallScriptRunner {
 }
 
 contract EVMCallScriptDecoder is EVMCallScriptRunner {
-    function getScriptActionsCount(bytes script) internal constant returns (uint256 i) {
+    function getScriptActionsCount(bytes script) internal pure returns (uint256 i) {
         uint256 location = 0;
         while (location < script.length) {
             location += (0x14 + 0x04 + uint256(uint32At(script, location + 0x14)));
@@ -66,7 +66,7 @@ contract EVMCallScriptDecoder is EVMCallScriptRunner {
         }
     }
 
-    function getScriptAction(bytes script, uint256 i) internal constant returns (address, bytes) {
+    function getScriptAction(bytes script, uint256 i) internal pure returns (address, bytes) {
         uint256 location = 0;
         while (location < script.length) {
             if (i == 0) {
@@ -85,7 +85,8 @@ contract EVMCallScriptDecoder is EVMCallScriptRunner {
     }
 
     // From https://github.com/Arachnid/solidity-stringutils
-    function memcpy(uint dest, uint src, uint len) private {
+    // WARNING: HAS SIDE EFFECTS IN MEMORY
+    function memcpy(uint dest, uint src, uint len) pure private {
         // Copy word-length chunks while possible
         for (; len >= 32; len -= 32) {
             assembly {

--- a/contracts/common/EVMCallScript.sol
+++ b/contracts/common/EVMCallScript.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.4.18;
 
 // Inspired by https://github.com/reverendus/tx-manager
 
+
 contract EVMCallScriptRunner {
     event LogScriptCall(address indexed sender, address indexed src, address indexed dst);
 
@@ -57,6 +58,7 @@ contract EVMCallScriptRunner {
     }
 }
 
+
 contract EVMCallScriptDecoder is EVMCallScriptRunner {
     function getScriptActionsCount(bytes script) internal pure returns (uint256 i) {
         uint256 location = 0;
@@ -66,8 +68,9 @@ contract EVMCallScriptDecoder is EVMCallScriptRunner {
         }
     }
 
-    function getScriptAction(bytes script, uint256 i) internal pure returns (address, bytes) {
+    function getScriptAction(bytes script, uint256 position) internal pure returns (address, bytes) {
         uint256 location = 0;
+        uint i = position;
         while (location < script.length) {
             if (i == 0) {
                 uint256 length = uint256(uint32At(script, location + 0x14));
@@ -86,7 +89,11 @@ contract EVMCallScriptDecoder is EVMCallScriptRunner {
 
     // From https://github.com/Arachnid/solidity-stringutils
     // WARNING: HAS SIDE EFFECTS IN MEMORY
-    function memcpy(uint dest, uint src, uint len) pure private {
+    function memcpy(uint _dest, uint _src, uint _len) pure private {
+        uint256 src = _src;
+        uint256 dest = _dest;
+        uint256 len = _len;
+
         // Copy word-length chunks while possible
         for (; len >= 32; len -= 32) {
             assembly {

--- a/contracts/common/EtherToken.sol
+++ b/contracts/common/EtherToken.sol
@@ -2,6 +2,7 @@ pragma solidity 0.4.18;
 
 import "./erc677/ERC677Token.sol";
 
+
 contract EtherToken is ERC677Token {
     using SafeMath for uint256;
 
@@ -9,23 +10,13 @@ contract EtherToken is ERC677Token {
     string public symbol = "ETH";
     uint8 public decimals = 18;
 
-    function wrap() payable  public {
+    function wrap() payable public {
         _wrap(msg.sender, msg.value);
     }
 
     function wrapAndCall(address _receiver, bytes _data) payable public {
         _wrap(_receiver, msg.value);
         _postTransferCall(_receiver, msg.value, _data);
-    }
-
-    function _wrap(address _beneficiary, uint256 _amount) internal {
-        require(_amount > 0);
-
-        totalSupply = totalSupply.add(_amount);
-        balances[_beneficiary] = balances[_beneficiary].add(_amount);
-
-        Mint(_beneficiary, _amount);
-        Transfer(0, _beneficiary, _amount);
     }
 
     function unwrap() public {
@@ -43,6 +34,16 @@ contract EtherToken is ERC677Token {
         Transfer(msg.sender, 0, _amount);
 
         _recipient.transfer(_amount);
+    }
+
+    function _wrap(address _beneficiary, uint256 _amount) internal {
+        require(_amount > 0);
+
+        totalSupply = totalSupply.add(_amount);
+        balances[_beneficiary] = balances[_beneficiary].add(_amount);
+
+        Mint(_beneficiary, _amount);
+        Transfer(0, _beneficiary, _amount);
     }
 
     event Mint(address indexed actor, uint value);

--- a/contracts/common/EtherToken.sol
+++ b/contracts/common/EtherToken.sol
@@ -13,7 +13,7 @@ contract EtherToken is ERC677Token {
         _wrap(msg.sender, msg.value);
     }
 
-    function wrapAndCall(address _receiver, bytes _data) payable  public {
+    function wrapAndCall(address _receiver, bytes _data) payable public {
         _wrap(_receiver, msg.value);
         _postTransferCall(_receiver, msg.value, _data);
     }
@@ -28,11 +28,11 @@ contract EtherToken is ERC677Token {
         Transfer(0, _beneficiary, _amount);
     }
 
-    function unwrap()  public {
+    function unwrap() public {
         withdraw(msg.sender, balances[msg.sender]);
     }
 
-    function withdraw(address _recipient, uint256 _amount)  public {
+    function withdraw(address _recipient, uint256 _amount) public {
         require(_amount > 0);
         require(balances[msg.sender] >= _amount);
 

--- a/contracts/common/EtherToken.sol
+++ b/contracts/common/EtherToken.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 
 import "./erc677/ERC677Token.sol";
 

--- a/contracts/common/IForwarder.sol
+++ b/contracts/common/IForwarder.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity ^0.4.18;
 
 contract IForwarder {
     function isForwarder() public constant returns (bool) { return true; }

--- a/contracts/common/IForwarder.sol
+++ b/contracts/common/IForwarder.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.4.18;
 
 contract IForwarder {
-    function isForwarder() public constant returns (bool) { return true; }
+    function isForwarder() public pure returns (bool) { return true; }
 
-    function canForward(address _sender, bytes _evmCallScript) public constant returns (bool);
+    function canForward(address _sender, bytes _evmCallScript) public view returns (bool);
     function forward(bytes _evmCallScript) public;
 }

--- a/contracts/common/IForwarder.sol
+++ b/contracts/common/IForwarder.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.4.18;
 
+
 contract IForwarder {
     function isForwarder() public pure returns (bool) { return true; }
 

--- a/contracts/common/Initializable.sol
+++ b/contracts/common/Initializable.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.18;
+pragma solidity ^0.4.18;
 
 contract Initializable {
     uint256 private initializationBlock;
@@ -17,11 +17,11 @@ contract Initializable {
     /**
     * @return Block number in which the contract was initialized
     */
-    function getInitializationBlock() public constant returns (uint256) {
+    function getInitializationBlock() public view returns (uint256) {
         return initializationBlock;
     }
 
-    function getBlockNumber() internal constant returns (uint256) {
+    function getBlockNumber() internal view returns (uint256) {
         return block.number;
     }
 }

--- a/contracts/common/Initializable.sol
+++ b/contracts/common/Initializable.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.4.18;
 
+
 contract Initializable {
     uint256 private initializationBlock;
 
@@ -7,18 +8,19 @@ contract Initializable {
         require(initializationBlock == 0);
         _;
     }
-    /**
-    * @dev Function to be called by top level contract after initialization has finished.
-    */
-    function initialized() internal onlyInit {
-        initializationBlock = getBlockNumber();
-    }
 
     /**
     * @return Block number in which the contract was initialized
     */
     function getInitializationBlock() public view returns (uint256) {
         return initializationBlock;
+    }
+
+    /**
+    * @dev Function to be called by top level contract after initialization has finished.
+    */
+    function initialized() internal onlyInit {
+        initializationBlock = getBlockNumber();
     }
 
     function getBlockNumber() internal view returns (uint256) {

--- a/contracts/common/Initializable.sol
+++ b/contracts/common/Initializable.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 
 contract Initializable {
     uint256 private initializationBlock;

--- a/contracts/common/MiniMeToken.sol
+++ b/contracts/common/MiniMeToken.sol
@@ -1,5 +1,7 @@
 pragma solidity ^0.4.6;
 
+/* solium-disable */
+
 /*
     Copyright 2016, Jordi Baylina
 
@@ -359,11 +361,11 @@ contract MiniMeToken is Controlled {
         bool _transfersEnabled
     ) public returns(address)
     {
-        if (_snapshotBlock == 0)
-            _snapshotBlock = block.number;
+        uint256 snapshot = _snapshotBlock == 0 ? block.number - 1 : _snapshotBlock;
+
         MiniMeToken cloneToken = tokenFactory.createCloneToken(
             this,
-            _snapshotBlock,
+            snapshot,
             _cloneTokenName,
             _cloneDecimalUnits,
             _cloneTokenSymbol,
@@ -373,7 +375,7 @@ contract MiniMeToken is Controlled {
         cloneToken.changeController(msg.sender);
 
         // An event to make the token easy to find on the blockchain
-        NewCloneToken(address(cloneToken), _snapshotBlock);
+        NewCloneToken(address(cloneToken), snapshot);
         return address(cloneToken);
     }
 

--- a/contracts/common/TokenController.sol
+++ b/contracts/common/TokenController.sol
@@ -1,6 +1,8 @@
 pragma solidity ^0.4.18;
 
 /// @dev The token controller contract must implement these functions
+
+
 contract TokenController {
     /// @notice Called when `_owner` sends ether to the MiniMe Token contract
     /// @param _owner The address that sent the ether to create tokens

--- a/contracts/common/TokenController.sol
+++ b/contracts/common/TokenController.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity ^0.4.18;
 
 /// @dev The token controller contract must implement these functions
 contract TokenController {

--- a/contracts/common/erc677/ERC677Receiver.sol
+++ b/contracts/common/erc677/ERC677Receiver.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 
 contract ERC677Receiver {
     function tokenFallback(address from, uint256 amount, bytes data) external returns (bool success);

--- a/contracts/common/erc677/ERC677Receiver.sol
+++ b/contracts/common/erc677/ERC677Receiver.sol
@@ -1,5 +1,7 @@
 pragma solidity 0.4.18;
 
+/* solium-disable */
+
 contract ERC677Receiver {
     function tokenFallback(address from, uint256 amount, bytes data) external returns (bool success);
 }

--- a/contracts/common/erc677/ERC677Token.sol
+++ b/contracts/common/erc677/ERC677Token.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 
 import "./ERC677Receiver.sol";
 import "../../zeppelin/token/StandardToken.sol";

--- a/contracts/common/erc677/ERC677Token.sol
+++ b/contracts/common/erc677/ERC677Token.sol
@@ -1,5 +1,7 @@
 pragma solidity 0.4.18;
 
+/* solium-disable */
+
 import "./ERC677Receiver.sol";
 import "../../zeppelin/token/StandardToken.sol";
 

--- a/contracts/kernel/IKernel.sol
+++ b/contracts/kernel/IKernel.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 
 contract IKernel {
     event SetPermission(address indexed entity, address indexed app, bytes32 indexed role, bool allowed);

--- a/contracts/kernel/IKernel.sol
+++ b/contracts/kernel/IKernel.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.18;
+pragma solidity ^0.4.18;
 
 contract IKernel {
     event SetPermission(address indexed entity, address indexed app, bytes32 indexed role, bool allowed);
@@ -14,8 +14,8 @@ contract IKernel {
     function setAppCode(bytes32 _appId, address _code) external;
     function upgradeKernel(address _newKernel) external;
 
-    function getPermissionManager(address _app, bytes32 _role) constant public returns (address);
+    function getPermissionManager(address _app, bytes32 _role) view public returns (address);
 
-    function hasPermission(address _entity, address _app, bytes32 _role) constant public returns (bool);
-    function getAppCode(bytes32 _appId) constant public returns (address);
+    function hasPermission(address _entity, address _app, bytes32 _role) view public returns (bool);
+    function getAppCode(bytes32 _appId) view public returns (address);
 }

--- a/contracts/kernel/IKernel.sol
+++ b/contracts/kernel/IKernel.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.4.18;
 
+
 contract IKernel {
     event SetPermission(address indexed entity, address indexed app, bytes32 indexed role, bool allowed);
     event ChangePermissionManager(address indexed app, bytes32 indexed role, address indexed manager);

--- a/contracts/kernel/Kernel.sol
+++ b/contracts/kernel/Kernel.sol
@@ -5,6 +5,7 @@ import "./KernelStorage.sol";
 import "../common/Initializable.sol";
 import "../zeppelin/math/SafeMath.sol";
 
+
 contract Kernel is IKernel, KernelStorage, Initializable {
     bytes32 constant public CREATE_PERMISSIONS_ROLE = bytes32(1);
     bytes32 constant public UPGRADE_APPS_ROLE = bytes32(2);

--- a/contracts/kernel/Kernel.sol
+++ b/contracts/kernel/Kernel.sol
@@ -144,7 +144,7 @@ contract Kernel is IKernel, KernelStorage, Initializable {
     * @param _role Identifier for a group of actions in app
     * @return address of the manager for the permission
     */
-    function getPermissionManager(address _app, bytes32 _role) constant public returns (address) {
+    function getPermissionManager(address _app, bytes32 _role) view public returns (address) {
         return permissionManager[_app][_role];
     }
 
@@ -155,7 +155,7 @@ contract Kernel is IKernel, KernelStorage, Initializable {
     * @param _role Identifier for a group of actions in app
     * @return boolean indicating whether the ACL allows the role or not
     */
-    function hasPermission(address _entity, address _app, bytes32 _role) constant public returns (bool) {
+    function hasPermission(address _entity, address _app, bytes32 _role) view public returns (bool) {
         return permissions[_entity][_app][_role];
     }
 
@@ -164,7 +164,7 @@ contract Kernel is IKernel, KernelStorage, Initializable {
     * @param _appId Identifier for app
     * @return address for app code
     */
-    function getAppCode(bytes32 _appId) constant public returns (address) {
+    function getAppCode(bytes32 _appId) view public returns (address) {
         return appCode[_appId];
     }
 

--- a/contracts/kernel/Kernel.sol
+++ b/contracts/kernel/Kernel.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 
 import "./IKernel.sol";
 import "./KernelStorage.sol";

--- a/contracts/kernel/KernelProxy.sol
+++ b/contracts/kernel/KernelProxy.sol
@@ -9,7 +9,7 @@ contract KernelProxy is KernelStorage, DelegateProxy {
     *      can update the reference, which effectively upgrades the contract
     * @param _kernelImpl Address of the contract used as implementation for kernel
     */
-    function KernelProxy(address _kernelImpl)  public {
+    function KernelProxy(address _kernelImpl) public {
         kernelImpl = _kernelImpl;
     }
 

--- a/contracts/kernel/KernelProxy.sol
+++ b/contracts/kernel/KernelProxy.sol
@@ -3,6 +3,7 @@ pragma solidity 0.4.18;
 import "./KernelStorage.sol";
 import "../common/DelegateProxy.sol";
 
+
 contract KernelProxy is KernelStorage, DelegateProxy {
     /**
     * @dev KernelProxy is a proxy contract to a kernel implementation. The implementation

--- a/contracts/kernel/KernelProxy.sol
+++ b/contracts/kernel/KernelProxy.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 
 import "./KernelStorage.sol";
 import "../common/DelegateProxy.sol";

--- a/contracts/kernel/KernelStorage.sol
+++ b/contracts/kernel/KernelStorage.sol
@@ -1,5 +1,6 @@
 pragma solidity 0.4.18;
 
+
 contract KernelStorage {
     address public kernelImpl;
 }

--- a/contracts/kernel/KernelStorage.sol
+++ b/contracts/kernel/KernelStorage.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 
 contract KernelStorage {
     address public kernelImpl;

--- a/contracts/misc/Migrations.sol
+++ b/contracts/misc/Migrations.sol
@@ -1,6 +1,5 @@
 pragma solidity ^0.4.2;
 
-
 contract Migrations {
     address public owner;
     uint public lastCompletedMigration;
@@ -14,11 +13,11 @@ contract Migrations {
         owner = msg.sender;
     }
 
-    function setCompleted(uint completed) restricted  public {
+    function setCompleted(uint completed) restricted public {
         lastCompletedMigration = completed;
     }
 
-    function upgrade(address newAddress) restricted  public {
+    function upgrade(address newAddress) restricted public {
         Migrations upgraded = Migrations(newAddress);
         upgraded.setCompleted(lastCompletedMigration);
     }

--- a/contracts/misc/Migrations.sol
+++ b/contracts/misc/Migrations.sol
@@ -1,5 +1,8 @@
 pragma solidity ^0.4.2;
 
+/* solium-disable */
+
+
 contract Migrations {
     address public owner;
     uint public lastCompletedMigration;

--- a/contracts/zeppelin/math/SafeMath.sol
+++ b/contracts/zeppelin/math/SafeMath.sol
@@ -6,27 +6,27 @@ pragma solidity ^0.4.11;
  * @dev Math operations with safety checks that throw on error
  */
 library SafeMath {
-  function mul(uint256 a, uint256 b) internal constant returns (uint256) {
+  function mul(uint256 a, uint256 b) internal pure returns (uint256) {
     uint256 c = a * b;
-    assert(a == 0 || c / a == b);
+    require(a == 0 || c / a == b);
     return c;
   }
 
-  function div(uint256 a, uint256 b) internal constant returns (uint256) {
+  function div(uint256 a, uint256 b) internal pure returns (uint256) {
     // assert(b > 0); // Solidity automatically throws when dividing by 0
     uint256 c = a / b;
     // assert(a == b * c + a % b); // There is no case in which this doesn't hold
     return c;
   }
 
-  function sub(uint256 a, uint256 b) internal constant returns (uint256) {
-    assert(b <= a);
+  function sub(uint256 a, uint256 b) internal pure returns (uint256) {
+    require(b <= a);
     return a - b;
   }
 
-  function add(uint256 a, uint256 b) internal constant returns (uint256) {
+  function add(uint256 a, uint256 b) internal pure returns (uint256) {
     uint256 c = a + b;
-    assert(c >= a);
+    require(c >= a);
     return c;
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -804,9 +804,7 @@
       "dev": true
     },
     "bignumber.js": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.0.4.tgz",
-      "integrity": "sha512-LDXpJKVzEx2/OqNbG9mXBNvHuiRL4PzHCGfnANHMJ+fv68Ads3exDVJeGDJws+AoNEuca93bU3q+S0woeUaCdg==",
+      "version": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
       "dev": true
     },
     "binary-extensions": {
@@ -1166,9 +1164,9 @@
       }
     },
     "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+      "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
       "dev": true
     },
     "concat-map": {
@@ -1217,9 +1215,9 @@
       "dev": true
     },
     "coveralls": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.1.tgz",
-      "integrity": "sha1-1wu5rMGDXsTwY/+drFQjwXsR8Xg=",
+      "version": "2.13.3",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.13.3.tgz",
+      "integrity": "sha512-iiAmn+l1XqRwNLXhW8Rs5qHZRFMYp9ZIPjEOVRpC/c4so6Y/f4/lFi0FfR5B9cCqgyhkJ5cZmbvcVRfP8MHchw==",
       "dev": true,
       "requires": {
         "js-yaml": "3.6.1",
@@ -1242,8 +1240,8 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "commander": "2.11.0",
-            "is-my-json-valid": "2.16.1",
+            "commander": "2.12.2",
+            "is-my-json-valid": "2.17.1",
             "pinkie-promise": "2.0.1"
           }
         },
@@ -1290,7 +1288,7 @@
         "uuid": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-          "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ=",
+          "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
           "dev": true
         }
       }
@@ -1820,12 +1818,12 @@
       "dev": true
     },
     "eth-ens-namehash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.0.tgz",
-      "integrity": "sha1-lmFRe/wThyZZL6DxYLYG7NWHTvI=",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/eth-ens-namehash/-/eth-ens-namehash-2.0.8.tgz",
+      "integrity": "sha1-IprEbsqG1S4MmR58sq74P/D2i88=",
       "dev": true,
       "requires": {
-        "idna-uts46": "1.1.0",
+        "idna-uts46-hx": "2.3.1",
         "js-sha3": "0.5.7"
       },
       "dependencies": {
@@ -1844,9 +1842,9 @@
       "dev": true
     },
     "ethereumjs-abi": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.4.tgz",
-      "integrity": "sha1-m6G7BWSS0AwnJ59uzNTVgnWRLBo=",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/ethereumjs-abi/-/ethereumjs-abi-0.6.5.tgz",
+      "integrity": "sha1-WmN+8Wq0NHP6cqKa2QhxQFs/UkE=",
       "dev": true,
       "requires": {
         "bn.js": "4.11.8",
@@ -1904,15 +1902,6 @@
         "ethereumjs-tx": "1.3.3",
         "ethereumjs-util": "5.1.2",
         "merkle-patricia-tree": "2.2.0"
-      }
-    },
-    "ethereumjs-testrpc": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/ethereumjs-testrpc/-/ethereumjs-testrpc-6.0.1.tgz",
-      "integrity": "sha1-CdoVoUox2jhPsQwIwPqaxXasgTc=",
-      "dev": true,
-      "requires": {
-        "webpack": "3.6.0"
       }
     },
     "ethereumjs-testrpc-sc": {
@@ -2235,13 +2224,15 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+          "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
           "dev": true,
           "optional": true
         },
         "ajv": {
           "version": "4.11.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2251,18 +2242,21 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "aproba": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+          "integrity": "sha1-ldNgDwdxCqDpKYxyatXs8urLq6s=",
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2272,42 +2266,49 @@
         },
         "asn1": {
           "version": "0.2.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
           "dev": true,
           "optional": true
         },
         "assert-plus": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
           "dev": true,
           "optional": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
           "dev": true,
           "optional": true
         },
         "aws-sign2": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
           "dev": true,
           "optional": true
         },
         "aws4": {
           "version": "1.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
           "dev": true,
           "optional": true
         },
         "balanced-match": {
           "version": "0.4.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+          "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
           "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2316,7 +2317,8 @@
         },
         "block-stream": {
           "version": "0.0.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz",
+          "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
           "dev": true,
           "requires": {
             "inherits": "2.0.3"
@@ -2324,7 +2326,8 @@
         },
         "boom": {
           "version": "2.10.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
           "dev": true,
           "requires": {
             "hoek": "2.16.3"
@@ -2332,7 +2335,8 @@
         },
         "brace-expansion": {
           "version": "1.1.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+          "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
           "dev": true,
           "requires": {
             "balanced-match": "0.4.2",
@@ -2341,29 +2345,34 @@
         },
         "buffer-shims": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
           "dev": true
         },
         "caseless": {
           "version": "0.12.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
           "dev": true,
           "optional": true
         },
         "co": {
           "version": "4.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
           "dev": true
         },
         "combined-stream": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
           "dev": true,
           "requires": {
             "delayed-stream": "1.0.0"
@@ -2371,22 +2380,26 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
           "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
           "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "dev": true
         },
         "cryptiles": {
           "version": "2.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2395,7 +2408,8 @@
         },
         "dashdash": {
           "version": "1.14.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2404,7 +2418,8 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
@@ -2412,7 +2427,8 @@
         },
         "debug": {
           "version": "2.6.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2421,24 +2437,28 @@
         },
         "deep-extend": {
           "version": "0.4.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
           "dev": true,
           "optional": true
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
           "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "dev": true,
           "optional": true
         },
         "ecc-jsbn": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2447,24 +2467,28 @@
         },
         "extend": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
           "dev": true,
           "optional": true
         },
         "extsprintf": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+          "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA=",
           "dev": true
         },
         "forever-agent": {
           "version": "0.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
           "dev": true,
           "optional": true
         },
         "form-data": {
           "version": "2.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2475,12 +2499,14 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "dev": true
         },
         "fstream": {
           "version": "1.0.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+          "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
           "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
@@ -2491,7 +2517,8 @@
         },
         "fstream-ignore": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+          "integrity": "sha1-nDHa40dnAY/h0kmyTa2mfQktoQU=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2502,7 +2529,8 @@
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2518,7 +2546,8 @@
         },
         "getpass": {
           "version": "0.1.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2527,7 +2556,8 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
@@ -2535,7 +2565,8 @@
         },
         "glob": {
           "version": "7.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
@@ -2548,18 +2579,21 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+          "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
           "dev": true
         },
         "har-schema": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
           "dev": true,
           "optional": true
         },
         "har-validator": {
           "version": "4.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2569,13 +2603,15 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "dev": true,
           "optional": true
         },
         "hawk": {
           "version": "3.1.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2587,12 +2623,14 @@
         },
         "hoek": {
           "version": "2.16.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+          "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
           "dev": true
         },
         "http-signature": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2603,7 +2641,8 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "dev": true,
           "requires": {
             "once": "1.4.0",
@@ -2612,18 +2651,21 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "ini": {
           "version": "1.3.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
@@ -2631,24 +2673,28 @@
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
           "dev": true,
           "optional": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
           "dev": true,
           "optional": true
         },
         "jodid25519": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+          "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2657,19 +2703,22 @@
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
           "dev": true,
           "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
           "dev": true,
           "optional": true
         },
         "json-stable-stringify": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2678,19 +2727,22 @@
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
           "dev": true,
           "optional": true
         },
         "jsonify": {
           "version": "0.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
           "dev": true,
           "optional": true
         },
         "jsprim": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+          "integrity": "sha1-o7h+QCmNjDgFUtjMdiigu5WiKRg=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2702,7 +2754,8 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
@@ -2710,12 +2763,14 @@
         },
         "mime-db": {
           "version": "1.27.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
+          "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
           "dev": true
         },
         "mime-types": {
           "version": "2.1.15",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
+          "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
           "dev": true,
           "requires": {
             "mime-db": "1.27.0"
@@ -2723,7 +2778,8 @@
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
           "requires": {
             "brace-expansion": "1.1.7"
@@ -2731,12 +2787,14 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
           "requires": {
             "minimist": "0.0.8"
@@ -2744,13 +2802,15 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
           "dev": true,
           "optional": true
         },
         "node-pre-gyp": {
           "version": "0.6.36",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
+          "integrity": "sha1-22BBEst04NR3VU6bUFsXq936t4Y=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2767,7 +2827,8 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2777,7 +2838,8 @@
         },
         "npmlog": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+          "integrity": "sha512-ocolIkZYZt8UveuiDS0yAkkIjid1o7lPG8cYm05yNYzBn8ykQtaiPMEGp8fY9tKdDgm8okpdKzkvu1y9hUYugA==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2789,24 +2851,28 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
           "dev": true
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
           "requires": {
             "wrappy": "1.0.2"
@@ -2814,19 +2880,22 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.4",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+          "integrity": "sha1-Qv5tWVPfBsgGS+bxdsPQWqqjRkQ=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2836,35 +2905,41 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "dev": true
         },
         "performance-now": {
           "version": "0.2.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
           "dev": true
         },
         "punycode": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
           "dev": true,
           "optional": true
         },
         "qs": {
           "version": "6.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+          "integrity": "sha1-LgPo5C7kULjLPc5lvhv4l04d/ZU=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2876,7 +2951,8 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "dev": true,
               "optional": true
             }
@@ -2884,7 +2960,8 @@
         },
         "readable-stream": {
           "version": "2.2.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz",
+          "integrity": "sha1-z3jsb0ptHrQ9JkiMrJfwQudLf8g=",
           "dev": true,
           "requires": {
             "buffer-shims": "1.0.0",
@@ -2898,7 +2975,8 @@
         },
         "request": {
           "version": "2.81.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2928,7 +3006,8 @@
         },
         "rimraf": {
           "version": "2.6.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+          "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
           "dev": true,
           "requires": {
             "glob": "7.1.2"
@@ -2936,30 +3015,35 @@
         },
         "safe-buffer": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+          "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
           "dev": true
         },
         "semver": {
           "version": "5.3.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "dev": true,
           "optional": true
         },
         "sntp": {
           "version": "1.0.9",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2968,7 +3052,8 @@
         },
         "sshpk": {
           "version": "1.13.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+          "integrity": "sha1-/yo+T9BEl1Vf7Zezmg/YL6+zozw=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -2985,7 +3070,8 @@
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
-              "bundled": true,
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
               "dev": true,
               "optional": true
             }
@@ -2993,7 +3079,8 @@
         },
         "string-width": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
           "requires": {
             "code-point-at": "1.1.0",
@@ -3003,7 +3090,8 @@
         },
         "string_decoder": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz",
+          "integrity": "sha1-YuIA8DmVWmgQ2N8KM//A8BNmLZg=",
           "dev": true,
           "requires": {
             "safe-buffer": "5.0.1"
@@ -3011,13 +3099,15 @@
         },
         "stringstream": {
           "version": "0.0.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
           "dev": true,
           "optional": true
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
@@ -3025,13 +3115,15 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "2.2.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+          "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
           "dev": true,
           "requires": {
             "block-stream": "0.0.9",
@@ -3041,7 +3133,8 @@
         },
         "tar-pack": {
           "version": "3.4.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+          "integrity": "sha1-I74tf2cagzk3bL2wuP4/3r8xeYQ=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3057,7 +3150,8 @@
         },
         "tough-cookie": {
           "version": "2.3.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3066,7 +3160,8 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3075,30 +3170,35 @@
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
           "dev": true,
           "optional": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE=",
           "dev": true,
           "optional": true
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "dev": true
         },
         "uuid": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+          "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
           "dev": true,
           "optional": true
         },
         "verror": {
           "version": "1.3.6",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+          "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3107,7 +3207,8 @@
         },
         "wide-align": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "dev": true,
           "optional": true,
           "requires": {
@@ -3116,7 +3217,8 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
           "dev": true
         }
       }
@@ -3132,6 +3234,15 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
+    },
+    "ganache-cli": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/ganache-cli/-/ganache-cli-6.0.3.tgz",
+      "integrity": "sha512-C7a8su4Zwtootvcy9HtroshTsyUtLC51+aOGUREpy/G4CXbAuLa3nNQri2NyFdqGyOrm/D+jxYP/PWnnrGLyXg==",
+      "dev": true,
+      "requires": {
+        "webpack": "3.6.0"
+      }
     },
     "gauge": {
       "version": "2.7.4",
@@ -3452,10 +3563,10 @@
       "integrity": "sha512-sr1ZQph3UwHTR0XftSbK85OvBbxe/abLGzEnPENCQwmHf7sck8Oyu4ob3LgBxWWxRoM+QszeUyl7jbqapu2TqA==",
       "dev": true
     },
-    "idna-uts46": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/idna-uts46/-/idna-uts46-1.1.0.tgz",
-      "integrity": "sha1-vgmLK3wcq/vvh6i4D2JvrDc2auo=",
+    "idna-uts46-hx": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/idna-uts46-hx/-/idna-uts46-hx-2.3.1.tgz",
+      "integrity": "sha512-PWoF9Keq6laYdIRwwCdhTPl60xRqAloYNMQLiyUnG42VjT53oW07BXIRM+NK7eQjzXjAk2gUvX9caRxlnF9TAA==",
       "dev": true,
       "requires": {
         "punycode": "2.1.0"
@@ -3639,9 +3750,9 @@
       "dev": true
     },
     "is-my-json-valid": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.1.tgz",
-      "integrity": "sha512-ochPsqWS1WXj8ZnMIV0vnNXooaMhp7cyL4FMSIPKTtnV0Ha/T19G2b9kkhcNsabV9bxYkze7/aLZJb/bYuFduQ==",
+      "version": "2.17.1",
+      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.17.1.tgz",
+      "integrity": "sha512-Q2khNw+oBlWuaYvEEHtKSw/pCxD2L5Rc1C+UQme9X6JdRDh7m5D7HkozA0qa3DUkQ6VzCnEm8mVIQPyIRkI5sQ==",
       "dev": true,
       "requires": {
         "generate-function": "2.0.0",
@@ -5789,21 +5900,47 @@
       }
     },
     "solium": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/solium/-/solium-1.0.4.tgz",
-      "integrity": "sha512-IiWV5YLSuRplNAOXMhrOH8yi5J4PbNEbZaxhSdxtgEeK9tA6OXcAvwTsq2I8qRzqf6m3Bxr6OhiGboQaLtGC4Q==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/solium/-/solium-1.1.2.tgz",
+      "integrity": "sha512-2CvpbiU0msntDkK+X6y3qCcRqg+W7Bf237BrHPTP32zufK7OCaINK4ci7UEMnusbEW41njJwLitN0h32C3rVKA==",
       "dev": true,
       "requires": {
         "ajv": "5.2.3",
         "chokidar": "1.7.0",
         "colors": "1.1.2",
-        "commander": "2.11.0",
+        "commander": "2.12.2",
         "js-string-escape": "1.0.1",
         "lodash": "4.17.4",
         "sol-digger": "0.0.2",
-        "sol-explore": "1.6.2",
-        "solium-plugin-security": "0.0.2",
-        "solparse": "1.4.0"
+        "sol-explore": "1.6.1",
+        "solium-plugin-security": "0.1.1",
+        "solparse": "2.2.2",
+        "text-table": "0.2.0"
+      },
+      "dependencies": {
+        "sol-explore": {
+          "version": "1.6.1",
+          "resolved": "https://registry.npmjs.org/sol-explore/-/sol-explore-1.6.1.tgz",
+          "integrity": "sha1-tZ8HPGn+MyVg1aEMMrqMp/KYbPs=",
+          "dev": true
+        }
+      }
+    },
+    "solium-plugin-security": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/solium-plugin-security/-/solium-plugin-security-0.1.1.tgz",
+      "integrity": "sha512-kpLirBwIq4mhxk0Y/nn5cQ6qdJTI+U1LO3gpoNIcqNaW+sI058moXBe2UiHs+9wvF9IzYD49jcKhFTxcR9u9SQ==",
+      "dev": true
+    },
+    "solparse": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/solparse/-/solparse-2.2.2.tgz",
+      "integrity": "sha512-TKX0Foi/N73nKco65+boo0YTtifFVEEXEPQkN4b1GkkEsXLXyV1TnvvIeT0qg9lEPLdi4Ri5WUWYVJipnSny+Q==",
+      "dev": true,
+      "requires": {
+        "mocha": "4.1.0",
+        "pegjs": "0.10.0",
+        "yargs": "10.0.3"
       },
       "dependencies": {
         "ansi-regex": {
@@ -5816,6 +5953,12 @@
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
           "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
           "dev": true
         },
         "debug": {
@@ -5869,9 +6012,9 @@
           "dev": true
         },
         "mocha": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
-          "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.1.0.tgz",
+          "integrity": "sha512-0RVnjg1HJsXY2YFDoTNzcc1NKhYuXKRrBAG2gDygmJJA136Cs2QlRliZG1mA0ap7cuaT30mw16luAeln+4RiNA==",
           "dev": true,
           "requires": {
             "browser-stdout": "1.3.0",
@@ -5895,17 +6038,6 @@
             "execa": "0.7.0",
             "lcid": "1.0.0",
             "mem": "1.1.0"
-          }
-        },
-        "solparse": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/solparse/-/solparse-1.4.0.tgz",
-          "integrity": "sha512-fEeAJzHBw0b/Md3OU4TZHyTDtQ2NkvvilMh7ApkWC+W9sN8VvCPzttOcA93gbgsm8Cq6j9Hw/tgzb86NabXyew==",
-          "dev": true,
-          "requires": {
-            "mocha": "4.0.1",
-            "pegjs": "0.10.0",
-            "yargs": "10.0.3"
           }
         },
         "string-width": {
@@ -5959,25 +6091,19 @@
             "string-width": "2.1.1",
             "which-module": "2.0.0",
             "y18n": "3.2.1",
-            "yargs-parser": "8.0.0"
+            "yargs-parser": "8.1.0"
           }
         },
         "yargs-parser": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.0.0.tgz",
-          "integrity": "sha1-IdR2Mw5agieaS4gTRb8GYQLiGcY=",
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
+          "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
           "dev": true,
           "requires": {
             "camelcase": "4.1.0"
           }
         }
       }
-    },
-    "solium-plugin-security": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/solium-plugin-security/-/solium-plugin-security-0.0.2.tgz",
-      "integrity": "sha512-2xjJoAWeY1Ynz1ExxtCVSABAMPrDV/AqhjE/X6jXMHJ1ubT+j9kDt5HKaHNOCa2MWoTna281HzcZlTioR1/ObA==",
-      "dev": true
     },
     "source-list-map": {
       "version": "2.0.0",
@@ -6223,6 +6349,12 @@
         "xtend": "4.0.1"
       }
     },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
@@ -6278,14 +6410,14 @@
       "dev": true
     },
     "truffle": {
-      "version": "3.4.11",
-      "resolved": "https://registry.npmjs.org/truffle/-/truffle-3.4.11.tgz",
-      "integrity": "sha512-DT5nArmVW0wPCPMCHrYyVrhBbTiA2VLTOXIbbHULHTCJSFOSsDK6EDKA2nrtzq3fZ6i++ZS34iIjLNY27dBLXQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/truffle/-/truffle-4.0.4.tgz",
+      "integrity": "sha512-keAkRNNfU3W7yUMRDF3YHoqmqdv6TChXY0g+RuPpxnRHfspXVtIKwuN2pV07jzY/RbDsIKShcSyF7VBV7eZUvg==",
       "dev": true,
       "requires": {
-        "mocha": "3.5.0",
+        "mocha": "3.5.3",
         "original-require": "1.0.1",
-        "solc": "0.4.15"
+        "solc": "0.4.18"
       },
       "dependencies": {
         "commander": {
@@ -6324,9 +6456,9 @@
           "dev": true
         },
         "mocha": {
-          "version": "3.5.0",
-          "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
-          "integrity": "sha512-pIU2PJjrPYvYRqVpjXzj76qltO9uBYI7woYAMoxbSefsa+vqAfptjoeevd6bUgwD0mPIO+hv9f7ltvsNreL2PA==",
+          "version": "3.5.3",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+          "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
           "dev": true,
           "requires": {
             "browser-stdout": "1.3.0",
@@ -6336,10 +6468,24 @@
             "escape-string-regexp": "1.0.5",
             "glob": "7.1.1",
             "growl": "1.9.2",
+            "he": "1.1.1",
             "json3": "3.3.2",
             "lodash.create": "3.1.1",
             "mkdirp": "0.5.1",
             "supports-color": "3.1.2"
+          }
+        },
+        "solc": {
+          "version": "0.4.18",
+          "resolved": "https://registry.npmjs.org/solc/-/solc-0.4.18.tgz",
+          "integrity": "sha512-Kq+O3PNF9Pfq7fB+lDYAuoqRdghLmZyfngsg0h1Hj38NKAeVHeGPOGeZasn5KqdPeCzbMFvaGyTySxzGv6aXCg==",
+          "dev": true,
+          "requires": {
+            "fs-extra": "0.30.0",
+            "memorystream": "0.3.1",
+            "require-from-string": "1.2.1",
+            "semver": "5.4.1",
+            "yargs": "4.8.1"
           }
         },
         "supports-color": {
@@ -6354,16 +6500,16 @@
       }
     },
     "truffle-config": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/truffle-config/-/truffle-config-1.0.2.tgz",
-      "integrity": "sha1-RCtUzx2Gfgm4ggGnvYQpvPSiJJI=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/truffle-config/-/truffle-config-1.0.4.tgz",
+      "integrity": "sha512-E8pvJNAIjs7LNsjkYeS2dgoOnLoSBrTwb1xF5lJwfvZmGMFpKvVL1sa5jpFxozpf/WkRn/rfxy8zTdb3pq16jA==",
       "dev": true,
       "requires": {
         "find-up": "2.1.0",
         "lodash": "4.17.4",
         "original-require": "1.0.1",
         "truffle-error": "0.0.2",
-        "truffle-provider": "0.0.2"
+        "truffle-provider": "0.0.4"
       },
       "dependencies": {
         "find-up": {
@@ -6415,13 +6561,13 @@
       }
     },
     "truffle-provider": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/truffle-provider/-/truffle-provider-0.0.2.tgz",
-      "integrity": "sha1-UmFNwEva+Hj2Q5Kzh+ZDL5ybzG8=",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/truffle-provider/-/truffle-provider-0.0.4.tgz",
+      "integrity": "sha512-yVxxjocxnJcFspQ0T4Rjq/1wvvm3iLxidb6oa1EAX5LsnSQLPG8wAM5+JLlJ4FDBsqJdZLGOq1RR5Ln/w7x5JA==",
       "dev": true,
       "requires": {
         "truffle-error": "0.0.2",
-        "web3": "0.19.1"
+        "web3": "0.20.3"
       }
     },
     "tty-browserify": {
@@ -6625,12 +6771,12 @@
       }
     },
     "web3": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-0.19.1.tgz",
-      "integrity": "sha1-52PVsRB8S8JKvU+MvuG6Nlnm6zE=",
+      "version": "0.20.3",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-0.20.3.tgz",
+      "integrity": "sha1-yqRDc9yIFayHZ73ba6cwc5ZMqos=",
       "dev": true,
       "requires": {
-        "bignumber.js": "4.0.4",
+        "bignumber.js": "git+https://github.com/frozeman/bignumber.js-nolookahead.git#57692b3ecfc98bbdd6b3a516cb2353652ea49934",
         "crypto-js": "3.1.8",
         "utf8": "2.1.2",
         "xhr2": "0.1.4",

--- a/package.json
+++ b/package.json
@@ -3,13 +3,13 @@
   "version": "2.0.1",
   "description": "Core contracts for Aragon",
   "scripts": {
-    "test": "npm run testrpc:dev && truffle test --network rpc",
+    "test": "npm run ganache-cli:dev && truffle test --network rpc",
     "lint": "solium --dir ./contracts",
-    "coverage": "npm run testrpc:coverage && node_modules/.bin/solidity-coverage",
+    "coverage": "npm run ganache-cli:coverage && node_modules/.bin/solidity-coverage",
     "console": "node_modules/.bin/truffle console",
-    "testrpc:dev": "scripts/testrpc.sh",
-    "testrpc:coverage": "SOLIDITY_COVERAGE=true scripts/testrpc.sh",
-    "migrate:dev": "npm run testrpc:dev && npm run migrate:dev:contracts",
+    "ganache-cli:dev": "scripts/ganache-cli.sh",
+    "ganache-cli:coverage": "SOLIDITY_COVERAGE=true scripts/ganache-cli.sh",
+    "migrate:dev": "npm run ganache-cli:dev && npm run migrate:dev:contracts",
     "migrate:dev:contracts": "truffle migrate --all --network rpc;",
     "generate:artifacts-dev": "npm run migrate:dev; truffle exec --network rpc scripts/generate_artifacts.js"
   },
@@ -26,15 +26,15 @@
   ],
   "license": "GPL-3.0",
   "devDependencies": {
-    "coveralls": "^2.13.1",
-    "eth-ens-namehash": "^2.0.0",
-    "ethereumjs-abi": "^0.6.4",
-    "ethereumjs-testrpc": "^6.0.1",
+    "coveralls": "^2.13.3",
+    "eth-ens-namehash": "^2.0.8",
+    "ethereumjs-abi": "^0.6.5",
+    "ganache-cli": "^6.0.3",
     "mocha-lcov-reporter": "^1.3.0",
     "solidity-coverage": "^0.3.5",
-    "solium": "^1.0.4",
-    "truffle": "^3.4.9",
-    "truffle-config": "^1.0.2",
+    "solium": "^1.1.2",
+    "truffle": "^4.0.4",
+    "truffle-config": "^1.0.4",
     "truffle-hdwallet-provider": "0.0.3"
   }
 }

--- a/scripts/ganache-cli.sh
+++ b/scripts/ganache-cli.sh
@@ -17,7 +17,7 @@ start_testrpc() {
   if [ "$SOLIDITY_COVERAGE" = true ]; then
     node_modules/.bin/testrpc-sc -i 16 --gasLimit 0xfffffffffff --port "$testrpc_port"  > /dev/null &
   else
-    node_modules/.bin/testrpc -i 15 --gasLimit 7000000 > /dev/null &
+    node_modules/.bin/ganache-cli -i 15 --gasLimit 7000000 > /dev/null &
   fi
 
   testrpc_pid=$!

--- a/test/kernel_apps.js
+++ b/test/kernel_apps.js
@@ -47,6 +47,10 @@ contract('Kernel apps', accounts => {
                 await app.initialize()
             })
         })
+
+        it('should return values', async () => {
+            assert.equal(await app.stringTest(), 'hola', 'string test')
+        })
     })
 
     context('not initializing on proxy constructor', () => {

--- a/test/mocks/AppStub.sol
+++ b/test/mocks/AppStub.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 
 import "../../contracts/apps/App.sol";
 

--- a/test/mocks/AppStub.sol
+++ b/test/mocks/AppStub.sol
@@ -5,6 +5,7 @@ import "../../contracts/apps/App.sol";
 contract AppSt {
     uint a;
     bool public initialized;
+    string public stringTest;
 }
 
 contract AppStub is App, AppSt {
@@ -13,13 +14,14 @@ contract AppStub is App, AppSt {
     function initialize() {
         require(!initialized);
         initialized = true;
+        stringTest = "hola";
     }
 
     function setValue(uint i) auth(ROLE) {
         a = i;
     }
 
-    function getValue() constant returns (uint){
+    function getValue() constant returns (uint) {
         return a;
     }
 }

--- a/test/mocks/ERC677Stub.sol
+++ b/test/mocks/ERC677Stub.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 
 import "../../contracts/common/erc677/ERC677Receiver.sol";
 

--- a/test/mocks/ExecutionTarget.sol
+++ b/test/mocks/ExecutionTarget.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 
 contract ExecutionTarget {
     uint public counter;

--- a/test/mocks/Executor.sol
+++ b/test/mocks/Executor.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 
 import "../../contracts/common/EVMCallScript.sol";
 

--- a/test/mocks/UpgradedKernel.sol
+++ b/test/mocks/UpgradedKernel.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.4.15;
+pragma solidity 0.4.18;
 
 import "../../contracts/kernel/Kernel.sol";
 

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -1,12 +1,8 @@
-var HDWalletProvider = require('truffle-hdwallet-provider');
+var HDWalletProvider = require('truffle-hdwallet-provider')
 
 const mnemonic = 'stumble story behind hurt patient ball whisper art swift tongue ice alien';
 
-let developmentProvider, ropstenProvider, kovanProvider = {}
-
-if (!process.env.SOLIDITY_COVERAGE){
-  developmentProvider = require('ethereumjs-testrpc').provider({ gasLimit: 1e8, network_id: 15 })
-}
+let ropstenProvider, kovanProvider = {}
 
 if (process.env.LIVE_NETWORKS) {
   ropstenProvider = new HDWalletProvider(mnemonic, 'https://ropsten.infura.io/')
@@ -15,11 +11,6 @@ if (process.env.LIVE_NETWORKS) {
 
 module.exports = {
   networks: {
-    development: {
-      network_id: 15,
-      provider: developmentProvider,
-      gas: 9e6,
-    },
     rpc: {
       network_id: 15,
       host: 'localhost',


### PR DESCRIPTION
Closes #167 

Also locks critical contracts to 0.4.18 and 'interfaces' to `^0.4.18`, so it closes #158 and closes #160 (cc @sohkai please review this)

Didn't bother to update anything ERC677 or MiniMe as those are getting replace soon.