### PR TITLE
Use != for address checks

### DIFF
--- a/contracts/apps/AppProxy.sol
+++ b/contracts/apps/AppProxy.sol
@@ -27,7 +27,7 @@ contract AppProxy is AppStorage, DelegateProxy {
 
     function () payable public {
         address target = kernel.getAppCode(appId);
-        require(target > 0); // if app code hasn't been set yet, don't call
+        require(target != 0); // if app code hasn't been set yet, don't call
         delegatedFwd(target, msg.data);
     }
 }


### PR DESCRIPTION
Using `>` feels less correct that `!=` given that addresses don't really make sense having "greater" or "lesser" comparisons.