### PR TITLE
Add comments to Initializable

### DIFF
--- a/contracts/common/Initializable.sol
+++ b/contracts/common/Initializable.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.4.18;
 
 
 contract Initializable {
-    uint256 private initializationBlock;
+    uint256 public initializationBlock;
 
     modifier onlyInit {
         require(initializationBlock == 0);
@@ -10,20 +10,9 @@ contract Initializable {
     }
 
     /**
-    * @return Block number in which the contract was initialized
-    */
-    function getInitializationBlock() public view returns (uint256) {
-        return initializationBlock;
-    }
-
-    /**
     * @dev Function to be called by top level contract after initialization has finished.
     */
     function initialized() internal onlyInit {
-        initializationBlock = getBlockNumber();
-    }
-
-    function getBlockNumber() internal view returns (uint256) {
-        return block.number;
+        initializationBlock = block.number;
     }
 }

--- a/contracts/common/Initializable.sol
+++ b/contracts/common/Initializable.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.4.18;
 
 
 contract Initializable {
-    uint256 public initializationBlock;
+    uint256 private initializationBlock;
 
     modifier onlyInit {
         require(initializationBlock == 0);
@@ -10,9 +10,20 @@ contract Initializable {
     }
 
     /**
+    * @return Block number in which the contract was initialized
+    */
+    function getInitializationBlock() public view returns (uint256) {
+        return initializationBlock;
+    }
+
+    /**
     * @dev Function to be called by top level contract after initialization has finished.
     */
     function initialized() internal onlyInit {
-        initializationBlock = block.number;
+        initializationBlock = getBlockNumber();
+    }
+
+    function getBlockNumber() internal view returns (uint256) {
+        return block.number;
     }
 }

--- a/contracts/common/Initializable.sol
+++ b/contracts/common/Initializable.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.4.18;
 
 
 contract Initializable {
+    // Kept private to protect against modifications from subclasses
     uint256 private initializationBlock;
 
     modifier onlyInit {
@@ -23,6 +24,11 @@ contract Initializable {
         initializationBlock = getBlockNumber();
     }
 
+    /**
+    * @dev Returns the current block number.
+    *      Using a function rather than `block.number` allows us to easily mock the block number in
+    *      tests.
+    */
     function getBlockNumber() internal view returns (uint256) {
         return block.number;
     }

--- a/test/kernel_acl.js
+++ b/test/kernel_acl.js
@@ -29,7 +29,7 @@ contract('Kernel ACL', accounts => {
     })
 
     it('has correct initialization block', async () => {
-        assert.equal(await kernel.getInitializationBlock(), await getBlockNumber(), 'initialization block should be correct')
+        assert.equal(await kernel.initializationBlock(), await getBlockNumber(), 'initialization block should be correct')
     })
 
     it('throws on reinitialization', async () => {

--- a/test/kernel_acl.js
+++ b/test/kernel_acl.js
@@ -29,7 +29,7 @@ contract('Kernel ACL', accounts => {
     })
 
     it('has correct initialization block', async () => {
-        assert.equal(await kernel.initializationBlock(), await getBlockNumber(), 'initialization block should be correct')
+        assert.equal(await kernel.getInitializationBlock(), await getBlockNumber(), 'initialization block should be correct')
     })
 
     it('throws on reinitialization', async () => {


### PR DESCRIPTION
~Not sure if there was a plan to make more use of these functions in `Initializable`, but as they are it doesn't really make sense to keep them.~

Adds a few comments to `Initializable` for implementation details.